### PR TITLE
Add Road Distance between stops

### DIFF
--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -14,6 +14,7 @@ struct BusResponse {
   int stop_count;
   int unique_stop_count;
   double length;
+  double curvature;
 };
 
 struct StopResponse {
@@ -21,6 +22,8 @@ struct StopResponse {
 };
 
 struct StopInfo {
+  // Distances to other stops.
+  std::unordered_map<std::string, int> dists;
   Coords coords;
   std::set<std::string> buses;
 };
@@ -34,19 +37,20 @@ class BusManager {
   std::optional<StopResponse> GetStopInfo(const std::string &stop) const;
 
  private:
-  void AddStop(const std::string &stop,
-               Coords coords);
+  void AddStop(const std::string &stop, Coords coords,
+               std::vector<RoadDistance> stops);
 
-  void AddBus(const std::string &bus,
-              std::vector<std::string> stops);
+  void AddBus(std::string bus, std::vector<std::string> stops);
 
  private:
   struct BusInfo {
     std::vector<std::string> stops;
     int unique_stop_count;
     double distance;
+    double curvature;
   };
-  double ComputeDistance(const std::vector<std::string> &stops);
+  double ComputeGeoDistance(const std::vector<std::string> &stops) const;
+  double ComputeRoadDistance(const std::vector<std::string> &stops) const;
 
   std::unordered_map<std::string, StopInfo> stop_info_;
   std::unordered_map<std::string, BusInfo> bus_info_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,12 @@ int main() {
   using namespace rm;
 
   auto input = ReadInputRequests(std::cin);
-  if (!input) return 0;
+  auto output = ReadOutputRequests(std::cin);
+  if (!input || !output) return -1;
 
   BusManager bm(std::move(*input));
 
-  auto output = ReadOutputRequests(std::cin);
-  if (!output) return 0;
-  for (auto &req : std::move(*output))
-    ProcessRequest(bm, req, std::cout);
+  for (auto &req : *output)
+    ProcessRequest(bm, std::move(req), std::cout);
   return 0;
 }

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -17,7 +17,8 @@ void ProcessBusRequest(const BusManager &bm,
   os << "Bus " << request.bus << ": " << resp->stop_count
      << " stops on route, " << resp->unique_stop_count
      << " unique stops, " << std::setprecision(6)
-     << resp->length << " route length\n";
+     << resp->length << " route length, " << std::setprecision(7)
+     << resp->curvature << " curvature\n";
 }
 
 void ProcessStopRequest(const BusManager &bm,

--- a/src/request_reader.cpp
+++ b/src/request_reader.cpp
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#include <exception>
 
 namespace {
 std::optional<int> ToInt(std::string_view sv) {
@@ -121,15 +120,22 @@ std::optional<PostStopRequest> ParsePostStopRequest(std::string_view sv) {
   if (pos == sv.npos) return std::nullopt;
 
   auto lat = ToDouble(ReadNextToken(sv, ","));
-  auto lon = ToDouble(ReadNextToken(sv, ""));
+  auto lon = ToDouble(ReadNextToken(sv, ","));
   if (!lat || !lon) return std::nullopt;
+  sr.coords.latitude = *lat;
+  sr.coords.longitude = *lon;
 
-  try {
-    sr.coords.latitude = *lat;
-    sr.coords.longitude = *lon;
-  } catch (std::exception &ex) {
-    return std::nullopt;
+  while (!sv.empty()) {
+    auto dist_sv = ReadNextToken(sv, " ");
+    if (dist_sv.find_first_of('m') == dist_sv.npos) return std::nullopt;
+    auto dist = ToInt(ReadNextToken(dist_sv, "m"));
+    if (!dist) return std::nullopt;
+    if (ReadNextToken(sv, " ") != "to") return std::nullopt;
+    auto stop_to = ReadNextToken(sv, ",");
+    if (stop_to.empty()) return std::nullopt;
+    sr.stops.emplace_back(RoadDistance{std::string(stop_to), *dist});
   }
+
   return sr;
 }
 

--- a/src/request_types.h
+++ b/src/request_types.h
@@ -23,9 +23,16 @@ struct Coords {
   double latitude, longitude;
 };
 
+struct RoadDistance {
+  std::string destination;
+  int distance;
+};
+
 struct PostStopRequest {
   std::string stop;
   Coords coords;
+  // Pairs of stop_to and dist from stop to stop_to.
+  std::vector<RoadDistance> stops;
 };
 
 using PostRequest = std::variant<PostBusRequest, PostStopRequest>;

--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -4,7 +4,6 @@
 
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 TEST(TestBusManager, TestGetBusInfo) {
@@ -40,7 +39,8 @@ TEST(TestBusManager, TestGetBusInfo) {
                             "stop4"}},
               PostStopRequest{
                   .stop = "stop1",
-                  .coords = {55.611087, 37.20829}},
+                  .coords = {55.611087, 37.20829},
+                  .stops = {{"stop2", 3000}}},
               PostStopRequest{
                   .stop = "stop2",
                   .coords = {55.595884, 37.209755}},
@@ -49,7 +49,8 @@ TEST(TestBusManager, TestGetBusInfo) {
                   .coords = {55.632761, 37.333324}},
               PostStopRequest{
                   .stop = "stop4",
-                  .coords = {55.574371, 37.6517}},
+                  .coords = {55.574371, 37.6517},
+                  .stops = {{"stop5", 4000}, {"stop3", 4000}}},
               PostStopRequest{
                   .stop = "stop5",
                   .coords = {55.581065, 37.64839}},
@@ -66,8 +67,8 @@ TEST(TestBusManager, TestGetBusInfo) {
           .requests = {GetBusRequest{.bus = "Bus1"},
                        GetBusRequest{.bus = "Bus2"},
                        GetBusRequest{.bus = "none"}},
-          .want = {BusResponse{5, 3, 20939.5},
-                   BusResponse{6, 5, 4371.02},
+          .want = {BusResponse{5, 3, 2.35535e+04},
+                   BusResponse{6, 5, 7598.15},
                    std::nullopt},
       },
   };
@@ -79,7 +80,7 @@ TEST(TestBusManager, TestGetBusInfo) {
       auto got = bm.GetBusInfo(requests[i].bus);
 
       if (!want[i].has_value()) {
-        EXPECT_TRUE(!got.has_value());
+        EXPECT_TRUE(!got.has_value()) << name;
         continue;
       }
 
@@ -170,7 +171,7 @@ TEST(TestBusManager, TestGetStopInfo) {
       auto got = bm.GetStopInfo(requests[i].stop);
 
       if (!want[i].has_value()) {
-        EXPECT_TRUE(!got.has_value());
+        EXPECT_TRUE(!got.has_value()) << name;
         continue;
       }
 

--- a/tests/request_reader_test.cpp
+++ b/tests/request_reader_test.cpp
@@ -182,6 +182,51 @@ TEST(TestParseRequests, PostStopRequest) {
           .want = std::nullopt,
       },
       TestCase{
+          .name = "Wrong extended format - no 'm' after length",
+          .input = "stop1: 55.611087, 37.20829, 3900 to stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - no length",
+          .input = "stop1: 55.611087, 37.20829, m to stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - no 'to'",
+          .input = "stop1: 55.611087, 37.20829, 3900m  stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - incorrect preposition",
+          .input = "stop1: 55.611087, 37.20829, 3900m an stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - no STOP_NAME",
+          .input = "stop1: 55.611087, 37.20829, 3900m to ",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - extra symbol after a number",
+          .input = "stop1: 55.611087, 37.20829, 3900km to stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - no space between m and to",
+          .input = "stop1: 55.611087, 37.20829, 3900mto stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - float value",
+          .input = "stop1: 55.611087, 37.20829, 3900.56m to stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
+          .name = "Wrong extended format - space before m",
+          .input = "stop1: 55.611087, 37.20829, 3900 m to stop2",
+          .want = std::nullopt,
+      },
+      TestCase{
           .name = "Positive coords",
           .input = "stop1: 18.407908, 23.355151",
           .want = PostStopRequest{
@@ -190,10 +235,10 @@ TEST(TestParseRequests, PostStopRequest) {
       },
       TestCase{
           .name = "Same coords",
-          .input = "stop2: 18.407908, 18.407908",
+          .input = "stop2: 18.407908e2, 18.407908",
           .want = PostStopRequest{
               .stop = "stop2",
-              .coords = {18.407908, 18.407908}},
+              .coords = {18.407908e2, 18.407908}},
       },
       TestCase{
           .name = "Extra spaces",
@@ -222,6 +267,48 @@ TEST(TestParseRequests, PostStopRequest) {
           .want = PostStopRequest{
               .stop = "stop5",
               .coords = {-57.407908, -23.355151}},
+      },
+      TestCase{
+          .name = "Trailing ','",
+          .input = "stop1: -55.574371, -37.6517,",
+          .want = PostStopRequest{
+              .stop = "stop1",
+              .coords = {-55.574371, -37.6517}},
+      },
+      TestCase{
+          .name = "Extended format - one stop",
+          .input = "stop1: 55.611087, 37.20829, 3900m to stop2",
+          .want = PostStopRequest{
+              .stop = "stop1",
+              .coords = {55.611087, 37.20829},
+              .stops = {{"stop2", 3900}}},
+      },
+      TestCase{
+          .name = "Extended format - several stops",
+          .input = "stop1: -55.574371, -37.6517, 7500m to stop2, "
+                   "1800m to stop3, 2400m to stop4",
+          .want = PostStopRequest{
+              .stop = "stop1",
+              .coords = {-55.574371, -37.6517},
+              .stops = {{"stop2", 7500}, {"stop3", 1800}, {"stop4", 2400}}},
+      },
+      TestCase{
+          .name = "Extended format - several stops long names",
+          .input = "long stop 1: -55.574371, -37.6517, 7500m to long stop 2, "
+                   "1800m to long stop 3, 2400m to long stop 4",
+          .want = PostStopRequest{
+              .stop = "long stop 1",
+              .coords = {-55.574371, -37.6517},
+              .stops = {{"long stop 2", 7500}, {"long stop 3", 1800},
+                        {"long stop 4", 2400}}},
+      },
+      TestCase{
+          .name = "Extended format - Trailing ','",
+          .input = "stop1: -55.574371, -37.6517, 7500m to stop2,",
+          .want = PostStopRequest{
+              .stop = "stop1",
+              .coords = {-55.574371, -37.6517},
+              .stops = {{"stop2", 7500}}},
       },
   };
 
@@ -415,7 +502,8 @@ TEST(TestReadRequests, InputRequests) {
                    .stops = {"stop2", "stop4", "stop7", "stop2"}},
                PostStopRequest{
                    .stop = "Stop2",
-                   .coords = {35.395105, 82.385629}}},
+                   .coords = {35.395105, 82.385629},
+                   .stops = {{"stop1", 6000000}}}},
           },
       }
   };


### PR DESCRIPTION
New Post Stop Request format:
`Stop {stop}: {latitude}, {longitude}, {distance1}m to {stop1}, {distance2}m to {stop2}, ...`
Adds the coordinates of `{stop}` and road lengths from `{stop}` to `{stopX}` which is `{distanceX}`.
Road length from `{stopX}` to `{stop}` also sets equal to `{distanceX}` (unless the distance from `{stopX}` to `{stop}` is being set explicitly when adding `{stopX}`).

New Get Bus Request output format:
`Bus {bus}: {stop_count} stops on route, {unique_stop_count} unique stops, {length} route length, {curvature} curvature`. 
`{length}` is the sum of all the distances between stops on the route, where distance is either provided in post stop request, or computed as orthodromic distance using the `{latitude}` and `{longitude}` if it wasn't provided explicitly. 
`{curvature}` is computed as `{length} / geo_length`, where `geo_length` is the sum of all the orthodromic distances between stops on the route. `{curvature}` is always  >= 1.