### PR TITLE
Remove RoadDistance struct.

### DIFF
--- a/src/request_types.h
+++ b/src/request_types.h
@@ -26,11 +26,6 @@ struct Coords {
   double latitude, longitude;
 };
 
-struct RoadDistance {
-  std::string destination;
-  int distance;
-};
-
 struct PostStopRequest {
   std::string stop;
   Coords coords;


### PR DESCRIPTION
Never used. Firstly seemed to be used in ```struct StopInfo```, as ```vector<RoadDistance>```, but later was changed to ```unordered_map<string, int>``` because adding a stop in ```BusManager::AddStop``` we need to find an element in a container on each iteration and this way I reduced one iteration time complexity to O(1).