### PR TITLE
Fix bug of json::Node: string literal convertioin to bool.

### DIFF
--- a/lib/json/include/json.h
+++ b/lib/json/include/json.h
@@ -26,6 +26,10 @@ class Node final : std::variant<std::monostate,
  public:
   using variant::variant;
 
+  // Fix the bug when `const char*` gets interpreted as bool. Fixed in C++20.
+  explicit Node(const char *str);
+  Node &operator=(const char *str);
+
   inline const variant &GetBase() const { return *this; }
 
   inline bool IsArray() const {

--- a/lib/json/src/json.cpp
+++ b/lib/json/src/json.cpp
@@ -9,6 +9,14 @@
 #include <cctype>
 
 namespace json {
+Node::Node(const char *str) {
+  *this = str;
+}
+
+Node &Node::operator=(const char *str) {
+  return *this = std::string(str);
+}
+
 std::istream &ReadArray(std::istream &input, Node &arr) {
   List result;
   char c;


### PR DESCRIPTION
In std::variant `const char*` gets implicitely converted to `bool` instead of `std::string`. It impacts json::Node which is inhereted from std::variant. Implement custom constructor and operator= for json::Node.