### PR TITLE
Fix RenderingSettings bug.

### DIFF
--- a/src/request_types.h
+++ b/src/request_types.h
@@ -25,7 +25,7 @@ struct RenderingSettings {
   double padding;
   double stop_radius;
   double line_width;
-  int16_t stop_label_font_size;
+  int stop_label_font_size;
   svg::Point stop_label_offset;
   svg::Color underlayer_color;
   double underlayer_width;


### PR DESCRIPTION
Changed `stop_label_font_size` type to int because required boundaries are [0, 100000] and int16_t doesn't meet these requirements.