### PR TITLE
Refactoring of route maintaining method

### DIFF
--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -17,6 +17,7 @@ struct BusResponse {
   int unique_stop_count;
   double length;
   double curvature;
+  bool is_roundtrip;
 };
 
 struct StopResponse {
@@ -45,7 +46,8 @@ class BusManager {
   void AddStop(const std::string &stop, sphere::Coords coords,
                const std::map<std::string, int> &stops);
 
-  void AddBus(std::string bus, std::vector<std::string> stops);
+  void AddBus(std::string bus, std::vector<std::string> stops,
+              bool is_roundtrip);
 
  private:
   StopDict stop_info_;

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,7 @@ struct BusInfo {
   int unique_stop_count;
   double distance;
   double curvature;
+  bool is_roundtrip;
 };
 
 struct RouteInfo {

--- a/src/distance_computer.cpp
+++ b/src/distance_computer.cpp
@@ -7,17 +7,19 @@
 
 namespace rm {
 double ComputeGeoDistance(const std::vector<std::string> &stops,
-                          const StopDict &dict) {
+                          const StopDict &dict, bool two_way_bypass) {
   double distance = 0;
   for (int i = 1; i < stops.size(); ++i) {
     distance += sphere::CalculateDistance(dict.at(stops[i - 1]).coords,
                                           dict.at(stops[i]).coords);
   }
+  if (two_way_bypass)
+    distance *= 2;
   return distance;
 }
 
 double ComputeRoadDistance(const std::vector<std::string> &stops,
-                           const StopDict &dict) {
+                           const StopDict &dict, bool two_way_bypass) {
   double distance = 0;
   for (int i = 1; i < stops.size(); ++i) {
     auto &dists = dict.at(stops[i - 1]).dists;
@@ -27,6 +29,17 @@ double ComputeRoadDistance(const std::vector<std::string> &stops,
     else
       distance += sphere::CalculateDistance(dict.at(stops[i - 1]).coords,
                                             dict.at(stops[i]).coords);
+  }
+  if (two_way_bypass) {
+    for (int i = static_cast<int>(stops.size()) - 2; i >= 0; --i) {
+      auto &dists = dict.at(stops[i + 1]).dists;
+
+      if (auto found = dists.find(stops[i]); found != dists.end())
+        distance += found->second;
+      else
+        distance += sphere::CalculateDistance(dict.at(stops[i + 1]).coords,
+                                              dict.at(stops[i]).coords);
+    }
   }
   return distance;
 }

--- a/src/distance_computer.h
+++ b/src/distance_computer.h
@@ -8,10 +8,10 @@
 
 namespace rm {
 double ComputeGeoDistance(const std::vector<std::string> &stops,
-                          const StopDict &dict);
+                          const StopDict &dict, bool two_way_bypass);
 
 double ComputeRoadDistance(const std::vector<std::string> &stops,
-                           const StopDict &dict);
+                           const StopDict &dict, bool two_way_bypass);
 }
 
 #endif // ROOT_MANAGER_SRC_DISTANCE_COMPUTER_H_

--- a/src/map_renderer.h
+++ b/src/map_renderer.h
@@ -15,14 +15,19 @@
 namespace rm {
 class MapRenderer {
  public:
+  struct Route {
+    std::vector<std::string_view> route;
+    bool is_roundtrip;
+  };
+
   static std::unique_ptr<MapRenderer> Create(
-      std::map<std::string_view, std::vector<std::string_view>> buses,
+      std::map<std::string_view, Route> buses,
       std::map<std::string_view, sphere::Coords> stops,
       const RenderingSettings &settings);
 
   std::string GetMap() const;
  private:
-  MapRenderer(std::map<std::string_view, std::vector<std::string_view>> buses,
+  MapRenderer(std::map<std::string_view, Route> buses,
               std::map<std::string_view, sphere::Coords> stops,
               const RenderingSettings &settings);
 

--- a/src/request_parser.cpp
+++ b/src/request_parser.cpp
@@ -155,12 +155,10 @@ std::optional<PostBusRequest> ParsePostBusRequest(json::Dict dict) {
 
   PostBusRequest br;
   br.bus = name->second.ReleaseString();
+  br.is_roundtrip = is_roundtrip->second.AsBool();
   for (auto &stop : stops->second.ReleaseArray()) {
     br.stops.push_back(stop.ReleaseString());
   }
-  if (!is_roundtrip->second.AsBool())
-    for (int i = static_cast<int>(br.stops.size()) - 2; i >= 0; --i)
-      br.stops.push_back(br.stops[i]);
 
   return br;
 }

--- a/src/request_types.h
+++ b/src/request_types.h
@@ -55,6 +55,7 @@ struct GetMapRequest {
 struct PostBusRequest {
   std::string bus;
   std::vector<std::string> stops;
+  bool is_roundtrip;
 };
 
 struct PostStopRequest {

--- a/src/route_manager.cpp
+++ b/src/route_manager.cpp
@@ -9,6 +9,18 @@
 #include "distance_computer.h"
 #include "request_types.h"
 
+namespace {
+std::vector<std::string> Route(const rm::BusInfo &bus_info) {
+  auto route = bus_info.stops;
+  if (!bus_info.is_roundtrip) {
+    for (int i = static_cast<int>(route.size()) - 2; i >= 0; --i) {
+      route.push_back(route[i]);
+    }
+  }
+  return route;
+}
+}
+
 namespace rm {
 RouteManager::RouteManager(const rm::StopDict &stop_info,
                            const rm::BusDict &bus_info,
@@ -40,19 +52,18 @@ void RouteManager::ReadStops(const rm::StopDict &stop_dict) {
 void RouteManager::ReadBuses(const rm::BusDict &bus_dict,
                              const rm::StopDict &stop_dict) {
   for (auto &[bus, bus_info] : bus_dict) {
-    int stop_count = bus_info.stops.size();
+    auto route = Route(bus_info);
+    int stop_count = route.size();
     for (int from = 0; from + 1 < stop_count; ++from) {
-      const auto depart = stop_ids_[bus_info.stops[from]].depart;
+      const auto depart = stop_ids_[route[from]].depart;
       double distance = 0.0;
       for (int to = from + 1; to < stop_count; ++to) {
-        std::vector<std::string> stops;
-        stops.emplace_back(bus_info.stops[to - 1]);
-        stops.emplace_back(bus_info.stops[to]);
-        distance += ComputeRoadDistance(stops, stop_dict);
+        distance += ComputeRoadDistance({route[to - 1], route[to]}, stop_dict,
+                                        false);
         edges_.emplace_back(RoadEdge{
             .bus = bus,
             .span_count = to - from});
-        const auto arrive = stop_ids_[bus_info.stops[to]].arrive;
+        const auto arrive = stop_ids_[route[to]].arrive;
         graph_.AddEdge(
             {
                 .from = depart,

--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -30,10 +30,12 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 1",
-                  .stops = {"stop 2", "stop 3", "stop 1", "stop 2"},
+                  .stops = {"stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -59,10 +61,12 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 3", "stop 1", "stop 2"},
+                  .stops = {"stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -129,11 +133,12 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = true,
       },
       TestCase{
-          .name = "Unknown stop along the route",
+          .name = "Unknown stop along the route(roundtrip)",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 4", "stop 1"},
+                  .is_roundtrip = true,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -152,11 +157,60 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = false,
       },
       TestCase{
-          .name = "Fixed \"Unknown stop along the route\"",
+          .name = "Fixed \"Unknown stop along the route(roundtrip)\"",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 4", "stop 1"},
+                  .is_roundtrip = false,
+              },
+              PostStopRequest{
+                  .stop = "stop 1",
+                  .coords = {11.111111, 11.111111},
+              },
+              PostStopRequest{
+                  .stop = "stop 2",
+                  .coords = {22.222222, 22.222222},
+              },
+              PostStopRequest{
+                  .stop = "stop 4",
+                  .coords = {33.333333, 33.333333},
+              },
+          },
+          .routing_settings = kTestRoutingSettings,
+          .want = true,
+      },
+      TestCase{
+          .name = "Unknown stop along the route(non-roundtrip)",
+          .config = {
+              PostBusRequest{
+                  .bus = "Bus 1",
+                  .stops = {"stop 1", "stop 2", "stop 4"},
+                  .is_roundtrip = false,
+              },
+              PostStopRequest{
+                  .stop = "stop 1",
+                  .coords = {11.111111, 11.111111},
+              },
+              PostStopRequest{
+                  .stop = "stop 2",
+                  .coords = {22.222222, 22.222222},
+              },
+              PostStopRequest{
+                  .stop = "stop 3",
+                  .coords = {33.333333, 33.333333},
+              },
+          },
+          .routing_settings = kTestRoutingSettings,
+          .want = false,
+      },
+      TestCase{
+          .name = "Fixed \"Unknown stop along the route(non-roundtrip)\"",
+          .config = {
+              PostBusRequest{
+                  .bus = "Bus 1",
+                  .stops = {"stop 1", "stop 2", "stop 4"},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -177,10 +231,6 @@ TEST(TestFactoryMethod, TestInitializing) {
       TestCase{
           .name = "Unknown stop among road_distances",
           .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
               PostStopRequest{
                   .stop = "stop 1",
                   .coords = {11.111111, 11.111111},
@@ -203,10 +253,6 @@ TEST(TestFactoryMethod, TestInitializing) {
       TestCase{
           .name = "Fixed \"Unknown stop among road_distances\"",
           .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
               PostStopRequest{
                   .stop = "stop 1",
                   .coords = {11.111111, 11.111111},
@@ -232,6 +278,12 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = true,
+              },
+              PostBusRequest{
+                  .bus = "Bus 2",
+                  .stops = {"stop 2", "stop 1", "stop 3"},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -258,11 +310,34 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = true,
       },
       TestCase{
-          .name = "Empty route",
+          .name = "Empty route(roundtrip)",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {},
+                  .is_roundtrip = true,
+              },
+              PostStopRequest{
+                  .stop = "stop 1",
+                  .coords = {11.111111, 11.111111},
+                  .stop_distances = {{"stop 2", 2000},},
+              },
+              PostStopRequest{
+                  .stop = "stop 2",
+                  .coords = {22.222222, 22.222222},
+                  .stop_distances = {{"stop 3", 2000},},
+              },
+          },
+          .routing_settings = kTestRoutingSettings,
+          .want = false,
+      },
+      TestCase{
+          .name = "Empty route(non-roundtrip)",
+          .config = {
+              PostBusRequest{
+                  .bus = "Bus 1",
+                  .stops = {},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -284,14 +359,17 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
+                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 2",
                   .stops = {"stop 2", "stop 3", "stop 1", "stop 2"},
+                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 3",
-                  .stops = {"stop 3", "stop 2", "stop 1", "stop 3"},
+                  .stops = {"stop 3", "stop 2"},
+                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -347,11 +425,15 @@ TEST(TestBusManager, TestGetBusInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"}},
+                  .stops = {"stop1", "stop2", "stop3"},
+                  .is_roundtrip = false
+              },
               PostBusRequest{
                   .bus = "Bus2",
                   .stops = {"stop4", "stop5", "stop6", "stop7", "stop8",
-                            "stop4"}},
+                            "stop4"},
+                  .is_roundtrip = true
+              },
               PostStopRequest{
                   .stop = "stop1",
                   .coords = {55.611087, 37.20829},
@@ -442,11 +524,14 @@ TEST(TestBusManager, TestGetStopInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"}},
+                  .stops = {"stop1", "stop2", "stop3"},
+                  .is_roundtrip = false},
               PostBusRequest{
                   .bus = "Bus2",
                   .stops = {"stop3", "stop4", "stop5", "stop6", "stop7",
-                            "stop3"}},
+                            "stop3"},
+                  .is_roundtrip = true
+              },
               PostStopRequest{
                   .stop = "stop1",
                   .coords = {55.611087, 37.20829}},
@@ -540,10 +625,14 @@ TEST(TestBusManager, TestFindRouteInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3", "stop1"}},
+                  .stops = {"stop1", "stop2", "stop3", "stop1"},
+                  .is_roundtrip = true,
+              },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop2", "stop3", "stop4", "stop3", "stop2"}},
+                  .stops = {"stop2", "stop3", "stop4"},
+                  .is_roundtrip = false,
+              },
               PostStopRequest{
                   .stop = "stop1",
                   .coords = {55.574371, 37.6517},
@@ -601,10 +690,14 @@ TEST(TestBusManager, TestFindRouteInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3", "stop1"}},
+                  .stops = {"stop1", "stop2", "stop3", "stop1"},
+                  .is_roundtrip = true
+              },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop4", "stop5", "stop6", "stop5", "stop4"}},
+                  .stops = {"stop4", "stop5", "stop6"},
+                  .is_roundtrip = false
+              },
               PostStopRequest{
                   .stop = "stop1",
                   .coords = {55.574371, 37.6517},
@@ -654,10 +747,14 @@ TEST(TestBusManager, TestFindRouteInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3", "stop1"}},
+                  .stops = {"stop1", "stop2", "stop3", "stop1"},
+                  .is_roundtrip = true,
+              },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop2", "stop3", "stop4", "stop3", "stop2"}},
+                  .stops = {"stop2", "stop3", "stop4"},
+                  .is_roundtrip = false,
+              },
               PostStopRequest{
                   .stop = "stop1",
                   .coords = {55.574371, 37.6517},

--- a/tests/map_renderer_test.cpp
+++ b/tests/map_renderer_test.cpp
@@ -70,7 +70,7 @@ const std::pair<std::string_view, rm::sphere::Coords> kDostoevsky =
 TEST(TestMapRenderer, TestInitializing) {
   struct TestCase {
     std::string name;
-    std::map<std::string_view, std::vector<std::string_view>> buses;
+    std::map<std::string_view, rm::MapRenderer::Route> buses;
     std::map<std::string_view, rm::sphere::Coords> stops;
     rm::RenderingSettings settings;
     bool want_fail;
@@ -112,16 +112,30 @@ TEST(TestMapRenderer, TestInitializing) {
       },
       TestCase{
           .name = "Bus route has unknown stop",
-          .buses = {{"Bus 1", {"Airport", "Dostoevsky", "Clemens"}}},
+          .buses = {{"Bus 1", {{"Airport", "Dostoevsky", "Clemens"}, false}}},
+          .stops = {kAirport, kClemens, kRWStation},
+          .settings = kTestRenderingSettings,
+          .want_fail = true
+      },
+      TestCase{
+          .name = "Bus route has unknown stop",
+          .buses = {{"Bus 1", {{"Airport", "Dostoevsky", "Clemens"}, true}}},
           .stops = {kAirport, kClemens, kRWStation},
           .settings = kTestRenderingSettings,
           .want_fail = true
       },
       TestCase{
           .name = "Valid config",
-          .buses = {{"Bus 1", {"Airport", "Clemens street", "RW station",
-                               "High Street"}}},
+          .buses = {{"Bus 1", {{"Airport", "Clemens street", "RW station",
+                                "High Street"}, true}}},
           .stops = {kAirport, kClemens, kRWStation, kHighStreet},
+          .settings = kTestRenderingSettings,
+          .want_fail = false
+      },
+      TestCase{
+          .name = "Valid config",
+          .buses = {{"Bus 1", {{"Airport", "RW station"}, false}}},
+          .stops = {kAirport, kRWStation, kClemens},
           .settings = kTestRenderingSettings,
           .want_fail = false
       }
@@ -139,7 +153,7 @@ TEST(TestMapRenderer, TestGetMap) {
 
   struct TestCase {
     std::string name;
-    std::map<std::string_view, std::vector<std::string_view>> buses;
+    std::map<std::string_view, MapRenderer::Route> buses;
     std::map<std::string_view, sphere::Coords> stops;
     RenderingSettings rendering_settings;
     std::string want;
@@ -163,10 +177,11 @@ TEST(TestMapRenderer, TestGetMap) {
       },
       TestCase{
           .name = "All stops are used",
-          .buses = {{"bus 1", {"Airport", "High Street", "Shop", "Airport"}},
-                    {"bus 2", {"High Street", "Airport", "Shop",
-                               "RW station", "Shop", "Airport",
-                               "High Street"}}},
+          .buses = {
+              {"bus 1", {{"Airport", "High Street", "Shop", "Airport"}, true}},
+              {"bus 2", {{"High Street", "Airport", "Shop",
+                          "RW station", "Shop", "Airport",
+                          "High Street"}, true}}},
           .stops = {kAirport, kShop, kHighStreet, kRWStation},
           .rendering_settings = kTestRenderingSettings,
           .want = SVG_DOC(
@@ -189,11 +204,11 @@ TEST(TestMapRenderer, TestGetMap) {
       },
       TestCase{
           .name = "Route number is greater than palette size",
-          .buses = {{"Bus 1", {"Shop", "Airport", "Shop"}},
-                    {"Bus 2", {"Shop", "Airport", "Shop"}},
-                    {"Bus 3", {"Shop", "Airport", "Shop"}},
-                    {"Bus 4", {"Shop", "Airport", "Shop"}},
-                    {"Bus 5", {"Shop", "Airport", "Shop"}}},
+          .buses = {{"Bus 1", {{"Shop", "Airport"}, false}},
+                    {"Bus 2", {{"Shop", "Airport", "Shop"}, true}},
+                    {"Bus 3", {{"Shop", "Airport"}, false}},
+                    {"Bus 4", {{"Shop", "Airport", "Shop"}, true}},
+                    {"Bus 5", {{"Shop", "Airport"}, false}}},
           .stops = {kShop, kAirport},
           .rendering_settings = kTestRenderingSettings,
           .want = SVG_DOC(

--- a/tests/request_parser_test.cpp
+++ b/tests/request_parser_test.cpp
@@ -46,7 +46,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", true}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop3", "stop1"}
+              .stops = {"stop1", "stop2", "stop3", "stop1"},
+              .is_roundtrip = true
           },
       },
       TestCase{
@@ -66,7 +67,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"}
+              .stops = {"stop1", "stop2", "stop3"},
+              .is_roundtrip = false
           },
       },
       TestCase{
@@ -84,7 +86,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"stops", json::List{"stop1", "stop2", "stop3"}}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"}
+              .stops = {"stop1", "stop2", "stop3"},
+              .is_roundtrip = false
           },
       },
       TestCase{
@@ -103,7 +106,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop1"}
+              .stops = {"stop1", "stop2"},
+              .is_roundtrip = false
           },
       },
       TestCase{
@@ -115,7 +119,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus1",
-              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
+              .stops = {"stop1", "stop2", "stop3"},
+              .is_roundtrip = false
           },
       },
       TestCase{
@@ -129,7 +134,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
           .want = PostBusRequest{
               .bus = "Bus1",
               .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-          },
+              .is_roundtrip = true,
+          }
       },
   };
 

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -40,7 +40,8 @@ bool operator==(const rm::BusResponse &lhs, const rm::BusResponse &rhs) {
 }
 
 bool operator==(const rm::PostBusRequest &lhs, const rm::PostBusRequest &rhs) {
-  return std::tie(lhs.bus, lhs.stops) == std::tie(rhs.bus, rhs.stops);
+  return std::tie(lhs.bus, lhs.stops, lhs.is_roundtrip)
+      == std::tie(rhs.bus, rhs.stops, rhs.is_roundtrip);
 }
 
 bool operator==(const rm::PostStopRequest &lhs,
@@ -215,7 +216,7 @@ std::ostream &operator<<(std::ostream &out,
 }
 
 std::ostream &operator<<(std::ostream &out, const rm::PostBusRequest &br) {
-  return out << br.bus << ": " << br.stops;
+  return out << br.bus << ": " << br.stops << ' ' << br.is_roundtrip;
 }
 
 std::ostream &operator<<(std::ostream &out, const rm::PostStopRequest &sr) {


### PR DESCRIPTION
Since now BusManager doesn't maintain expanded routes(ends in start point), but only `is_roundtrip` flag, which indicates whether this route should be expanded or not.