### PR TITLE
Refactor tests.

### DIFF
--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -8,6 +8,8 @@
 
 #include "test_utils.h"
 
+using namespace std;
+
 const rm::RoutingSettings kTestRoutingSettings{
     .bus_wait_time = 7,
     .bus_velocity = 54.0
@@ -401,14 +403,14 @@ TEST(TestBusManager, TestGetBusInfo) {
   using namespace rm;
 
   struct TestCase {
-    std::string name;
-    std::vector<PostRequest> config;
+    string name;
+    vector<PostRequest> config;
     RoutingSettings routing_settings;
-    std::vector<GetBusRequest> requests;
-    std::vector<std::optional<BusResponse>> want;
+    vector<GetBusRequest> requests;
+    vector<optional<BusResponse>> want;
   };
 
-  std::vector<TestCase> test_cases{
+  vector<TestCase> test_cases{
       TestCase{
           .name = "Requests to an empty database",
           .config = {},
@@ -416,9 +418,9 @@ TEST(TestBusManager, TestGetBusInfo) {
           .requests = {GetBusRequest{.bus = "123"},
                        GetBusRequest{.bus = "some bus"},
                        GetBusRequest{.bus = "s      s"},},
-          .want = {std::nullopt,
-                   std::nullopt,
-                   std::nullopt},
+          .want = {nullopt,
+                   nullopt,
+                   nullopt},
       },
       TestCase{
           .name = "Common requests",
@@ -467,7 +469,7 @@ TEST(TestBusManager, TestGetBusInfo) {
                        GetBusRequest{.bus = "none"}},
           .want = {BusResponse{5, 3, 2.35535e+04},
                    BusResponse{6, 5, 7598.15},
-                   std::nullopt},
+                   nullopt},
       },
   };
 
@@ -484,13 +486,13 @@ TEST(TestBusManager, TestGetBusInfo) {
         continue;
       }
 
-      std::pair p1{want[i]->stop_count, want[i]->unique_stop_count};
-      std::pair p2{got->stop_count, got->unique_stop_count};
+      pair p1{want[i]->stop_count, want[i]->unique_stop_count};
+      pair p2{got->stop_count, got->unique_stop_count};
       EXPECT_EQ(p1, p2) << name;
 
-      if (want[i] != std::nullopt)
+      if (want[i] != nullopt)
         EXPECT_TRUE(CompareLength(want[i]->length, got->length, 6))
-                  << name << " – " << std::setprecision(6) << "want: "
+                  << name << " – " << setprecision(6) << "want: "
                   << want[i]->length << ", got: " << got->length;
     }
   }
@@ -500,14 +502,14 @@ TEST(TestBusManager, TestGetStopInfo) {
   using namespace rm;
 
   struct TestCase {
-    std::string name;
-    std::vector<PostRequest> config;
+    string name;
+    vector<PostRequest> config;
     RoutingSettings routing_settings;
-    std::vector<GetStopRequest> requests;
-    std::vector<std::optional<StopInfo>> want;
+    vector<GetStopRequest> requests;
+    vector<optional<StopInfo>> want;
   };
 
-  std::vector<TestCase> test_cases{
+  vector<TestCase> test_cases{
       TestCase{
           .name = "Requests to an empty database",
           .config = {},
@@ -515,9 +517,9 @@ TEST(TestBusManager, TestGetStopInfo) {
           .requests = {GetStopRequest{.stop = "123"},
                        GetStopRequest{.stop = "some stop"},
                        GetStopRequest{.stop = "s      s"},},
-          .want = {std::nullopt,
-                   std::nullopt,
-                   std::nullopt},
+          .want = {nullopt,
+                   nullopt,
+                   nullopt},
       },
       TestCase{
           .name = "Common requests",
@@ -566,7 +568,7 @@ TEST(TestBusManager, TestGetStopInfo) {
               StopInfo{.buses = {"Bus1"}},
               StopInfo{.buses = {"Bus1", "Bus2"}},
               StopInfo{},
-              std::nullopt},
+              nullopt},
       },
   };
 
@@ -587,20 +589,20 @@ TEST(TestBusManager, TestGetStopInfo) {
 }
 
 TEST(TestBusManager, TestFindRouteInfo) {
+  using namespace rm;
+
   using WaitItem = rm::RouteInfo::WaitItem;
   using RoadItem = rm::RouteInfo::RoadItem;
 
-  using namespace rm;
-
   struct TestCase {
-    std::string name;
-    std::vector<PostRequest> config;
+    string name;
+    vector<PostRequest> config;
     RoutingSettings routing_settings;
-    std::vector<GetRouteRequest> requests;
-    std::vector<std::optional<RouteResponse>> want;
+    vector<GetRouteRequest> requests;
+    vector<optional<RouteResponse>> want;
   };
 
-  std::vector<TestCase> test_cases{
+  vector<TestCase> test_cases{
       TestCase{
           .name = "Requests to an empty database",
           .config = {},
@@ -615,8 +617,8 @@ TEST(TestBusManager, TestFindRouteInfo) {
                   .from = "stop 3",
                   .to = "stop 4"}
           },
-          .want = {std::nullopt,
-                   std::nullopt},
+          .want = {nullopt,
+                   nullopt},
       },
       // Requests for the paths between existing stops with at least one
       // path between.
@@ -738,8 +740,8 @@ TEST(TestBusManager, TestFindRouteInfo) {
                   .to = "stop5"
               }
           },
-          .want = {std::nullopt,
-                   std::nullopt},
+          .want = {nullopt,
+                   nullopt},
       },
       // requests for the path between existing stop and missing one.
       TestCase{
@@ -785,8 +787,8 @@ TEST(TestBusManager, TestFindRouteInfo) {
                   .to = "stop6"
               }
           },
-          .want = {std::nullopt,
-                   std::nullopt},
+          .want = {nullopt,
+                   nullopt},
       },
   };
 

--- a/tests/color_parser_test.cpp
+++ b/tests/color_parser_test.cpp
@@ -10,12 +10,12 @@
 #include "test_utils.h"
 
 TEST(TestColor, TestColor) {
-  using namespace rm;
+  using namespace svg;
 
   struct TestCase {
     std::string name;
     json::Node input;
-    std::optional<svg::Color> want;
+    std::optional<Color> want;
   };
 
   std::vector<TestCase> test_cases{
@@ -77,12 +77,12 @@ TEST(TestColor, TestColor) {
       TestCase{
           .name = "Valid color: Rgb type",
           .input = json::List{15, 14, 17},
-          .want = svg::Color{svg::Rgb{.red = 15, .green = 14, .blue = 17}}
+          .want = Color{Rgb{.red = 15, .green = 14, .blue = 17}}
       },
       TestCase{
           .name = "Valid color: Rgba type",
           .input = json::List{111, 144, 177, 0.555},
-          .want = svg::Color{svg::Rgba{
+          .want = Color{Rgba{
               .red = 111, .green = 144, .blue = 177, .alpha = 0.555}}
       }
   };
@@ -94,6 +94,6 @@ TEST(TestColor, TestColor) {
     }
 
     auto got = rm::AsColor(std::move(input));
-    EXPECT_TRUE(*want == got) << name;
+    EXPECT_EQ(*want, got) << name;
   }
 }

--- a/tests/coords_converter_test.cpp
+++ b/tests/coords_converter_test.cpp
@@ -6,6 +6,8 @@
 
 #include "src/coords_converter.h"
 
+using namespace std;
+
 const std::pair<std::string_view, rm::sphere::Coords> kAirport =
     {"Airport", {.latitude = 12.312245, .longitude = 52.119401}};
 const std::pair<std::string_view, rm::sphere::Coords> kShop =
@@ -16,12 +18,8 @@ const std::pair<std::string_view, rm::sphere::Coords> kRWStation =
     {"RW station", {.latitude = 63.015232, .longitude = -35.621022}};
 const std::pair<std::string_view, rm::sphere::Coords> kClemens =
     {"Clemens street", {.latitude = 49.102842, .longitude = 39.845290}};
-const std::pair<std::string_view, rm::sphere::Coords> kDostoevsky =
-    {"Dostoevsky street", {.latitude = 13.102921, .longitude = 12.432091}};
 
 TEST(TestSortStops, TestSortByLatitude) {
-  using namespace std;
-
   struct TestCase {
     string name;
     rm::renderer_utils::Stops stops;
@@ -53,8 +51,6 @@ TEST(TestSortStops, TestSortByLatitude) {
 }
 
 TEST(TestSortStops, TestSortByLongitude) {
-  using namespace std;
-
   struct TestCase {
     string name;
     rm::renderer_utils::Stops stops;
@@ -86,8 +82,6 @@ TEST(TestSortStops, TestSortByLongitude) {
 }
 
 TEST(TestAdjacentStops, TestAdjacentStops) {
-  using namespace std;
-
   struct TestCase {
     string name;
     rm::renderer_utils::Buses buses;
@@ -119,8 +113,6 @@ TEST(TestAdjacentStops, TestAdjacentStops) {
 }
 
 TEST(TestCompressCoords, TestCompressCoords) {
-  using namespace std;
-
   struct TestCase {
     string name;
     vector<string_view> stops;
@@ -160,8 +152,6 @@ TEST(TestCompressCoords, TestCompressCoords) {
 }
 
 TEST(TestSpreadStops, TestSpreadStops) {
-  using namespace std;
-
   struct TestCase {
     string name;
     vector<vector<string_view>> layers;

--- a/tests/map_renderer_test.cpp
+++ b/tests/map_renderer_test.cpp
@@ -81,8 +81,6 @@ const std::pair<std::string_view, rm::sphere::Coords> kRWStation =
     {"RW station", {.latitude = 63.015232, .longitude = -35.621022}};
 const std::pair<std::string_view, rm::sphere::Coords> kClemens =
     {"Clemens street", {.latitude = 49.102842, .longitude = 39.845290}};
-const std::pair<std::string_view, rm::sphere::Coords> kDostoevsky =
-    {"Dostoevsky street", {.latitude = 13.102921, .longitude = 12.432091}};
 
 TEST(TestMapRenderer, TestInitializing) {
   struct TestCase {

--- a/tests/settings_parser_test.cpp
+++ b/tests/settings_parser_test.cpp
@@ -58,12 +58,13 @@ TEST(TestParseSettings, TestRoutingSettings) {
 }
 
 TEST(TestParseSettings, TestRedneringSettings) {
+  using namespace std;
   using namespace rm;
 
   struct TestCase {
-    std::string name;
+    string name;
     json::Dict input;
-    std::optional<RenderingSettings> want;
+    optional<RenderingSettings> want;
   };
 
   const auto test_item = json::Dict{{"width", 412.1},
@@ -86,12 +87,12 @@ TEST(TestParseSettings, TestRedneringSettings) {
                                                           "stop_points",
                                                           "bus_lines",
                                                           "stop_labels"}}};
-  auto test_item_without = [&](std::string field) {
+  auto test_item_without = [&](string field) {
     auto item = test_item;
     item.erase(field);
     return item;
   };
-  auto test_item_replace = [&](std::string field, json::Node node) {
+  auto test_item_replace = [&](string field, json::Node node) {
     auto item = test_item;
     item[field] = std::move(node);
     return item;
@@ -117,159 +118,159 @@ TEST(TestParseSettings, TestRedneringSettings) {
                  MapLayer::kStopLabels}
   };
 
-  auto settings_replace_layers_with = [&](std::vector<MapLayer> layers) {
+  auto settings_replace_layers_with = [&](vector<MapLayer> layers) {
     auto item = settings;
     item.layers = std::move(layers);
     return item;
   };
 
-  std::vector<TestCase> test_cases{
+  vector<TestCase> test_cases{
       TestCase{
           .name = "Wrong format: no <width>",
           .input = test_item_without("width"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <height>",
           .input = test_item_without("height"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <padding>",
           .input = test_item_without("padding"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <stop_radius>",
           .input = test_item_without("stop_radius"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <line_width>",
           .input = test_item_without("line_width"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <stop_label_font_size>",
           .input = test_item_without("stop_label_font_size"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <stop_label_offset>",
           .input = test_item_without("stop_label_offset"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <underlayer_color>",
           .input = test_item_without("underlayer_color"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <underlayer_width>",
           .input = test_item_without("underlayer_width"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <color_palette>",
           .input = test_item_without("color_palette"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <bus_label_font_size>",
           .input = test_item_without("bus_label_font_size"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <bus_label_offset>",
           .input = test_item_without("bus_label_offset"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: no <layers>",
           .input = test_item_without("layers"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <width> isn't double",
           .input = test_item_replace("width", "123.4"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <height> isn't double",
           .input = test_item_replace("height", "321"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <padding> isn't double",
           .input = test_item_replace("padding", "214.7"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <stop_radius> isn't double",
           .input = test_item_replace("stop_radius", "8152"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <line_width> isn't double",
           .input = test_item_replace("line_width", "1234"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <stop_label_font_size> isn't int",
           .input = test_item_replace("stop_label_font_size", "123.4"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <stop_label_offset> isn't array",
           .input = test_item_replace("stop_label_offset",
                                      json::Dict{{"key", "value"}}),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <underlayer_color> isn't color",
           .input = test_item_replace("underlayer_color", 381),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <underlayer_width> isn't double",
           .input = test_item_replace("underlayer_width", "937.5"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <color_palette> isn't array",
           .input = test_item_replace("color_palette", "color1"),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <underlayer_color> isn't color",
           .input = test_item_replace("underlayer_color", 185),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <color_palette> contains not color",
           .input = test_item_replace("color_palette",
                                      json::List{"red", "purple", 15}),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <bus_label_font_size> isn't int",
           .input = test_item_replace("bus_label_font_size", 12.3),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <bus_label_offset> isn't array",
           .input = test_item_replace("bus_label_offset", 14.5),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <layers> isn't array",
           .input = test_item_replace("layers", json::Dict{{"1", 1}, {"2", 2}}),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Wrong format: <layers> contains not string",
           .input = test_item_replace("layers", json::List{"1", "2", 3}),
-          .want = std::nullopt
+          .want = nullopt
       },
       TestCase{
           .name = "Empty layers",

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -10,197 +10,131 @@
 
 #include "src/map_renderer_utils.h"
 
+using namespace std;
+
 namespace rm {
 bool CompareLength(double lhs, double rhs, int precision) {
-  std::stringstream ssl, ssr;
-  ssl << std::setprecision(precision) << lhs;
-  ssr << std::setprecision(precision) << rhs;
+  stringstream ssl, ssr;
+  ssl << setprecision(precision) << lhs;
+  ssr << setprecision(precision) << rhs;
   return ssl.str() == ssr.str();
 }
 
-bool operator==(const rm::GetBusRequest &lhs, const rm::GetBusRequest &rhs) {
+bool operator==(const GetBusRequest &lhs, const GetBusRequest &rhs) {
   return lhs.bus == rhs.bus;
 }
 
-bool operator==(const rm::GetStopRequest &lhs, const rm::GetStopRequest &rhs) {
+bool operator==(const GetStopRequest &lhs, const GetStopRequest &rhs) {
   return lhs.stop == rhs.stop;
 }
 
-bool operator==(const rm::GetRouteRequest &lhs,
-                const rm::GetRouteRequest &rhs) {
-  return std::tie(lhs.from, lhs.to, lhs.id)
-      == std::tie(rhs.from, rhs.to, rhs.id);
+bool operator==(const GetRouteRequest &lhs, const GetRouteRequest &rhs) {
+  return tie(lhs.from, lhs.to, lhs.id) == tie(rhs.from, rhs.to, rhs.id);
 }
 
-bool operator==(const rm::GetMapRequest &lhs, const rm::GetMapRequest &rhs) {
+bool operator==(const GetMapRequest &lhs, const GetMapRequest &rhs) {
   return lhs.id == rhs.id;
 }
 
-bool operator==(const rm::BusResponse &lhs, const rm::BusResponse &rhs) {
-  return std::tie(lhs.stop_count, lhs.unique_stop_count, lhs.length)
-      == std::tie(rhs.stop_count, rhs.unique_stop_count, rhs.length);
+bool operator==(const BusResponse &lhs, const BusResponse &rhs) {
+  return tie(lhs.stop_count, lhs.unique_stop_count, lhs.length)
+      == tie(rhs.stop_count, rhs.unique_stop_count, rhs.length);
 }
 
-bool operator==(const rm::PostBusRequest &lhs, const rm::PostBusRequest &rhs) {
-  return std::tie(lhs.bus, lhs.stops, lhs.is_roundtrip)
-      == std::tie(rhs.bus, rhs.stops, rhs.is_roundtrip);
+bool operator==(const PostBusRequest &lhs, const PostBusRequest &rhs) {
+  return tie(lhs.bus, lhs.stops, lhs.is_roundtrip)
+      == tie(rhs.bus, rhs.stops, rhs.is_roundtrip);
 }
 
-bool operator==(const rm::PostStopRequest &lhs,
-                const rm::PostStopRequest &rhs) {
-  return
-      std::tie(lhs.stop,
-               lhs.coords.latitude,
-               lhs.coords.longitude,
-               lhs.stop_distances)
-          == std::tie(rhs.stop, rhs.coords.latitude, rhs.coords.longitude,
-                      rhs.stop_distances);
+bool operator==(const PostStopRequest &lhs, const PostStopRequest &rhs) {
+  return tie(lhs.stop,
+             lhs.coords.latitude,
+             lhs.coords.longitude,
+             lhs.stop_distances)
+      == tie(rhs.stop,
+             rhs.coords.latitude,
+             rhs.coords.longitude,
+             rhs.stop_distances);
 }
 
-bool operator==(const rm::RoutingSettings &lhs,
-                const rm::RoutingSettings &rhs) {
-  return std::tie(lhs.bus_wait_time, lhs.bus_velocity)
-      == std::tie(rhs.bus_wait_time, rhs.bus_velocity);
+bool operator==(const RoutingSettings &lhs, const RoutingSettings &rhs) {
+  return tie(lhs.bus_wait_time, lhs.bus_velocity)
+      == tie(rhs.bus_wait_time, rhs.bus_velocity);
 }
 
-bool operator==(svg::Point lhs, svg::Point rhs) {
-  return std::tie(lhs.x, lhs.y) == std::tie(rhs.x, rhs.y);
-}
+bool operator==(const RenderingSettings &lhs, const RenderingSettings &rhs) {
+  using namespace svg;
 
-bool operator==(svg::Rgb lhs, svg::Rgb rhs) {
-  return std::tuple<int, int, int>(lhs.red, lhs.green, lhs.blue)
-      == std::tuple<int, int, int>(rhs.red, rhs.green, rhs.blue);
-}
-
-bool operator==(svg::Rgba lhs, svg::Rgba rhs) {
-  return
-      std::tuple<int, int, int, double>(lhs.red, lhs.green, lhs.blue, lhs.alpha)
-          == std::tuple<int, int, int, double>(rhs.red,
-                                               rhs.green,
-                                               rhs.blue,
-                                               rhs.alpha);
-}
-
-bool operator==(const svg::Color &lhs, const svg::Color &rhs) {
-  if (std::holds_alternative<std::string>(lhs) &&
-      std::holds_alternative<std::string>(rhs)) {
-    return std::get<std::string>(lhs) == std::get<std::string>(rhs);
-  }
-  if (std::holds_alternative<svg::Rgb>(lhs) &&
-      std::holds_alternative<svg::Rgb>(rhs)) {
-    return std::get<svg::Rgb>(lhs) == std::get<svg::Rgb>(rhs);
-  }
-  if (std::holds_alternative<svg::Rgba>(lhs) &&
-      std::holds_alternative<svg::Rgba>(rhs)) {
-    return std::get<svg::Rgba>(lhs) == std::get<svg::Rgba>(rhs);
-  }
-  return std::holds_alternative<std::monostate>(lhs) &&
-      std::holds_alternative<std::monostate>(rhs);
-}
-
-bool operator==(const rm::renderer_utils::Frame &lhs,
-                const rm::renderer_utils::Frame &rhs) {
-  return std::tie(lhs.width, lhs.height, lhs.padding) ==
-      std::tie(rhs.width, rhs.height, rhs.padding);
-}
-
-bool operator!=(const rm::renderer_utils::Frame &lhs,
-                const rm::renderer_utils::Frame &rhs) {
-  return !(lhs == rhs);
-}
-
-bool operator==(const rm::RenderingSettings &lhs,
-                const rm::RenderingSettings &rhs) {
-  if (std::tuple(lhs.stop_radius,
-                 lhs.line_width,
-                 lhs.underlayer_width,
-                 lhs.stop_label_font_size,
-                 lhs.color_palette.size(),
-                 lhs.layers) !=
-      std::tuple(rhs.stop_radius,
-                 rhs.line_width,
-                 rhs.underlayer_width,
-                 rhs.stop_label_font_size,
-                 rhs.color_palette.size(),
-                 rhs.layers))
-    return false;
-  if (lhs.frame != rhs.frame) return false;
-  if (lhs.stop_label_offset != rhs.stop_label_offset) return false;
-  if (lhs.underlayer_color != rhs.underlayer_color) return false;
-  for (int i = 0; i < lhs.color_palette.size(); ++i) {
-    if (lhs.color_palette[i] != rhs.color_palette[i]) return false;
-  }
-  return true;
+  return tuple(lhs.frame,
+               lhs.stop_radius,
+               lhs.line_width,
+               lhs.underlayer_width,
+               lhs.underlayer_color,
+               lhs.stop_label_font_size,
+               lhs.stop_label_offset,
+               lhs.color_palette.size(),
+               lhs.layers,
+               lhs.color_palette) ==
+      tuple(rhs.frame,
+            rhs.stop_radius,
+            rhs.line_width,
+            rhs.underlayer_width,
+            rhs.underlayer_color,
+            rhs.stop_label_font_size,
+            rhs.stop_label_offset,
+            rhs.color_palette.size(),
+            rhs.layers,
+            rhs.color_palette);
 }
 
 bool operator==(const RouteResponse::WaitItem &lhs,
                 const RouteResponse::WaitItem &rhs) {
-  return std::tie(lhs.stop, lhs.time) == std::tie(rhs.stop, rhs.time);
+  return tie(lhs.stop, lhs.time) == tie(rhs.stop, rhs.time);
 }
 
 bool operator==(const RouteResponse::RoadItem &lhs,
                 const RouteResponse::RoadItem &rhs) {
   if (!CompareLength(lhs.time, rhs.time, 9)) return false;
-  return std::tie(lhs.bus, lhs.span_count)
-      == std::tie(rhs.bus, rhs.span_count);
+  return tie(lhs.bus, lhs.span_count) == tie(rhs.bus, rhs.span_count);
 }
 
-bool operator==(const rm::RouteResponse &lhs, const rm::RouteResponse &rhs) {
-  return std::tie(lhs.items, lhs.time) == std::tie(rhs.items, rhs.time);
+bool operator==(const RouteResponse &lhs, const RouteResponse &rhs) {
+  return tie(lhs.items, lhs.time) == tie(rhs.items, rhs.time);
 }
 
-bool operator!=(const rm::GetBusRequest &lhs, const rm::GetBusRequest &rhs) {
+bool operator!=(const GetBusRequest &lhs, const GetBusRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::GetStopRequest &lhs, const rm::GetStopRequest &rhs) {
+bool operator!=(const GetStopRequest &lhs, const GetStopRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::GetRouteRequest &lhs,
-                const rm::GetRouteRequest &rhs) {
+bool operator!=(const GetRouteRequest &lhs, const GetRouteRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::GetMapRequest &lhs, const rm::GetMapRequest &rhs) {
+bool operator!=(const GetMapRequest &lhs, const GetMapRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::BusResponse &lhs, const rm::BusResponse &rhs) {
+bool operator!=(const BusResponse &lhs, const BusResponse &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::PostBusRequest &lhs,
-                const rm::PostBusRequest &rhs) { return !(lhs == rhs); }
-
-bool operator!=(const rm::PostStopRequest &lhs,
-                const rm::PostStopRequest &rhs) {
+bool operator!=(const PostBusRequest &lhs, const PostBusRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::RoutingSettings &lhs,
-                const rm::RoutingSettings &rhs) {
+bool operator!=(const PostStopRequest &lhs, const PostStopRequest &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(svg::Point lhs, svg::Point rhs) {
+bool operator!=(const RoutingSettings &lhs, const RoutingSettings &rhs) {
   return !(lhs == rhs);
 }
 
-bool operator!=(svg::Rgb lhs, svg::Rgb rhs) {
-  return !(lhs == rhs);
-}
-
-bool operator!=(svg::Rgba lhs, svg::Rgba rhs) {
-  return !(lhs == rhs);
-}
-
-bool operator!=(const svg::Color &lhs, const svg::Color &rhs) {
-  return !(lhs == rhs);
-}
-
-bool operator!=(const rm::RenderingSettings lhs,
-                const rm::RenderingSettings rhs) {
+bool operator!=(const RenderingSettings &lhs, const RenderingSettings &rhs) {
   return !(lhs == rhs);
 }
 
@@ -213,23 +147,22 @@ bool operator!=(const RouteResponse::RoadItem &lhs,
   return !(lhs == rhs);
 }
 
-bool operator!=(const rm::RouteResponse &lhs, const rm::RouteResponse &rhs) {
+bool operator!=(const RouteResponse &lhs, const RouteResponse &rhs) {
   return !(lhs == rhs);
 }
 
 template<typename T>
-std::ostream &operator<<(std::ostream &out,
-                         const std::vector<T> &str_v) {
+ostream &operator<<(ostream &out, const vector <T> &str_v) {
   for (auto &item : str_v)
     out << ' ' << item;
   return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::PostBusRequest &br) {
+ostream &operator<<(ostream &out, const PostBusRequest &br) {
   return out << br.bus << ": " << br.stops << ' ' << br.is_roundtrip;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::PostStopRequest &sr) {
+ostream &operator<<(ostream &out, const PostStopRequest &sr) {
   out << sr.stop << ": " << sr.coords.latitude << ' ' <<
       sr.coords.longitude << '\t';
   for (auto [stop, dist] : sr.stop_distances) {
@@ -238,39 +171,28 @@ std::ostream &operator<<(std::ostream &out, const rm::PostStopRequest &sr) {
   return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::GetBusRequest &br) {
+ostream &operator<<(ostream &out, const GetBusRequest &br) {
   return out << br.bus << " – " << br.id;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::GetStopRequest &br) {
+ostream &operator<<(ostream &out, const GetStopRequest &br) {
   return out << br.stop << " – " << br.id;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::GetMapRequest &mr) {
+ostream &operator<<(ostream &out, const GetMapRequest &mr) {
   return out << mr.id;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::BusResponse &br) {
+ostream &operator<<(ostream &out, const BusResponse &br) {
   return out << br.stop_count << ' ' << br.unique_stop_count << ' '
              << br.length;
 }
 
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RoutingSettings &settings) {
+ostream &operator<<(ostream &out, const RoutingSettings &settings) {
   return out << settings.bus_wait_time << ' ' << settings.bus_velocity;
 }
 
-std::ostream &operator<<(std::ostream &out, const svg::Point point) {
-  return out << '{' << point.x << ',' << point.y << '}';
-}
-
-std::ostream &operator<<(std::ostream &out,
-                         const rm::renderer_utils::Frame &frame) {
-  return out << frame.width << ' ' << frame.height << ' ' << frame.padding;
-}
-
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RenderingSettings &settings) {
+ostream &operator<<(ostream &out, const RenderingSettings &settings) {
   return out << settings.frame.width << ' ' << settings.frame.height << ' ' <<
              settings.frame.padding << ' ' << settings.stop_radius << ' ' <<
              settings.line_width << ' ' << settings.stop_label_font_size
@@ -279,24 +201,87 @@ std::ostream &operator<<(std::ostream &out,
              << ' ' << settings.color_palette;
 }
 
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RouteResponse::RoadItem &ri) {
+ostream &operator<<(ostream &out, const RouteResponse::RoadItem &ri) {
   return out << ri.bus << '-' << ri.time << '-' << ri.span_count;
 }
 
-std::ostream &operator<<(std::ostream &out, const RouteResponse::WaitItem &wi) {
+ostream &operator<<(ostream &out, const RouteResponse::WaitItem &wi) {
   return out << wi.stop << '-' << wi.time;
 }
 
-std::ostream &operator<<(std::ostream &out, const rm::RouteResponse &rr) {
-  return out << rr.time << ' ' << rr.items;
-}
-
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RouteResponse::Item &item) {
-  std::visit([&](auto &&var) {
+ostream &operator<<(ostream &out, const RouteResponse::Item &item) {
+  visit([&](auto &&var) {
     out << var;
   }, item);
   return out;
+}
+
+ostream &operator<<(ostream &out, const RouteResponse &rr) {
+  return out << rr.time << ' ' << rr.items;
+}
+}
+
+namespace rm::renderer_utils {
+bool operator==(const Frame &lhs, const Frame &rhs) {
+  return tie(lhs.width, lhs.height, lhs.padding) ==
+      tie(rhs.width, rhs.height, rhs.padding);
+}
+
+bool operator!=(const Frame &lhs, const Frame &rhs) {
+  return !(lhs == rhs);
+}
+
+ostream &operator<<(ostream &out, const Frame &frame) {
+  return out << frame.width << ' ' << frame.height << ' ' << frame.padding;
+}
+}
+
+namespace svg {
+bool operator==(Point lhs, Point rhs) {
+  return tie(lhs.x, lhs.y) == tie(rhs.x, rhs.y);
+}
+
+bool operator!=(Point lhs, Point rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(Rgb lhs, Rgb rhs) {
+  return tuple<int, int, int>(lhs.red, lhs.green, lhs.blue)
+      == tuple<int, int, int>(rhs.red, rhs.green, rhs.blue);
+}
+
+bool operator!=(Rgb lhs, Rgb rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(Rgba lhs, Rgba rhs) {
+  return
+      tuple<int, int, int, double>(lhs.red, lhs.green, lhs.blue, lhs.alpha) ==
+          tuple<int, int, int, double>(rhs.red, rhs.green, rhs.blue, rhs.alpha);
+}
+
+bool operator!=(Rgba lhs, Rgba rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const Color &lhs, const Color &rhs) {
+  if (holds_alternative<string>(lhs) && holds_alternative<string>(rhs)) {
+    return get<string>(lhs) == get<string>(rhs);
+  }
+  if (holds_alternative<Rgb>(lhs) && holds_alternative<Rgb>(rhs)) {
+    return get<Rgb>(lhs) == get<Rgb>(rhs);
+  }
+  if (holds_alternative<Rgba>(lhs) && holds_alternative<Rgba>(rhs)) {
+    return get<Rgba>(lhs) == get<Rgba>(rhs);
+  }
+  return holds_alternative<monostate>(lhs) && holds_alternative<monostate>(rhs);
+}
+
+bool operator!=(const Color &lhs, const Color &rhs) {
+  return !(lhs == rhs);
+}
+
+ostream &operator<<(ostream &out, const Point point) {
+  return out << '{' << point.x << ',' << point.y << '}';
 }
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -15,69 +15,41 @@
 namespace rm {
 bool CompareLength(double lhs, double rhs, int precision);
 
-bool operator==(const rm::BusResponse &lhs, const rm::BusResponse &rhs);
+bool operator==(const BusResponse &lhs, const BusResponse &rhs);
 
-bool operator!=(const rm::BusResponse &lhs, const rm::BusResponse &rhs);
+bool operator!=(const BusResponse &lhs, const BusResponse &rhs);
 
-bool operator==(const rm::GetBusRequest &lhs, const rm::GetBusRequest &rhs);
+bool operator==(const GetBusRequest &lhs, const GetBusRequest &rhs);
 
-bool operator!=(const rm::GetBusRequest &lhs, const rm::GetBusRequest &rhs);
+bool operator!=(const GetBusRequest &lhs, const GetBusRequest &rhs);
 
-bool operator==(const rm::GetStopRequest &lhs, const rm::GetStopRequest &rhs);
+bool operator==(const GetStopRequest &lhs, const GetStopRequest &rhs);
 
-bool operator!=(const rm::GetStopRequest &lhs, const rm::GetStopRequest &rhs);
+bool operator!=(const GetStopRequest &lhs, const GetStopRequest &rhs);
 
-bool operator==(const rm::GetRouteRequest &lhs, const rm::GetRouteRequest &rhs);
+bool operator==(const GetRouteRequest &lhs, const GetRouteRequest &rhs);
 
-bool operator!=(const rm::GetRouteRequest &lhs, const rm::GetRouteRequest &rhs);
+bool operator!=(const GetRouteRequest &lhs, const GetRouteRequest &rhs);
 
-bool operator==(const rm::GetMapRequest &lhs, const rm::GetMapRequest &rhs);
+bool operator==(const GetMapRequest &lhs, const GetMapRequest &rhs);
 
-bool operator!=(const rm::GetMapRequest &lhs, const rm::GetMapRequest &rhs);
+bool operator!=(const GetMapRequest &lhs, const GetMapRequest &rhs);
 
-bool operator==(const rm::PostBusRequest &lhs, const rm::PostBusRequest &rhs);
+bool operator==(const PostBusRequest &lhs, const PostBusRequest &rhs);
 
-bool operator!=(const rm::PostBusRequest &lhs, const rm::PostBusRequest &rhs);
+bool operator!=(const PostBusRequest &lhs, const PostBusRequest &rhs);
 
-bool operator==(const rm::PostStopRequest &lhs, const rm::PostStopRequest &rhs);
+bool operator==(const PostStopRequest &lhs, const PostStopRequest &rhs);
 
-bool operator!=(const rm::PostStopRequest &lhs, const rm::PostStopRequest &rhs);
+bool operator!=(const PostStopRequest &lhs, const PostStopRequest &rhs);
 
-bool operator==(const rm::RoutingSettings &lhs, const rm::RoutingSettings &rhs);
+bool operator==(const RoutingSettings &lhs, const RoutingSettings &rhs);
 
-bool operator!=(const rm::RoutingSettings &lhs, const rm::RoutingSettings &rhs);
+bool operator!=(const RoutingSettings &lhs, const RoutingSettings &rhs);
 
-bool operator==(svg::Point lhs, svg::Point rhs);
+bool operator==(const RenderingSettings &lhs, const RenderingSettings &rhs);
 
-bool operator!=(svg::Point lhs, svg::Point rhs);
-
-bool operator==(svg::Rgb lhs, svg::Rgb rhs);
-
-bool operator!=(svg::Rgb lhs, svg::Rgb rhs);
-
-bool operator==(svg::Rgba lhs, svg::Rgba rhs);
-
-bool operator!=(svg::Rgba lhs, svg::Rgba rhs);
-
-bool operator==(const svg::Color &lhs, const svg::Color &rhs);
-
-bool operator!=(const svg::Color &lhs, const svg::Color &rhs);
-
-bool operator==(const rm::renderer_utils::Frame &lhs,
-                const rm::renderer_utils::Frame &rhs);
-
-bool operator!=(const rm::renderer_utils::Frame &lhs,
-                const rm::renderer_utils::Frame &rhs);
-
-bool operator==(const rm::RenderingSettings &lhs,
-                const rm::RenderingSettings &rhs);
-
-bool operator!=(const rm::RenderingSettings &lhs,
-                const rm::RenderingSettings &rhs);
-
-bool operator==(const svg::Color &lhs, const svg::Color &rhs);
-
-bool operator!=(const svg::Color &lhs, const svg::Color &rhs);
+bool operator!=(const RenderingSettings &lhs, const RenderingSettings &rhs);
 
 bool operator==(const RouteResponse::WaitItem &lhs,
                 const RouteResponse::WaitItem &rhs);
@@ -91,39 +63,59 @@ bool operator==(const RouteResponse::RoadItem &lhs,
 bool operator!=(const RouteResponse::RoadItem &lhs,
                 const RouteResponse::RoadItem &rhs);
 
-bool operator==(const rm::RouteResponse &lhs, const rm::RouteResponse &rhs);
+bool operator==(const RouteResponse &lhs, const RouteResponse &rhs);
 
-bool operator!=(const rm::RouteResponse &lhs, const rm::RouteResponse &rhs);
+bool operator!=(const RouteResponse &lhs, const RouteResponse &rhs);
 
-std::ostream &operator<<(std::ostream &out, const rm::PostBusRequest &br);
+std::ostream &operator<<(std::ostream &out, const PostBusRequest &br);
 
-std::ostream &operator<<(std::ostream &out, const rm::PostStopRequest &sr);
+std::ostream &operator<<(std::ostream &out, const PostStopRequest &sr);
 
-std::ostream &operator<<(std::ostream &out, const rm::GetBusRequest &br);
+std::ostream &operator<<(std::ostream &out, const GetBusRequest &br);
 
-std::ostream &operator<<(std::ostream &out, const rm::GetMapRequest &br);
+std::ostream &operator<<(std::ostream &out, const GetMapRequest &br);
 
-std::ostream &operator<<(std::ostream &out, const rm::BusResponse &br);
+std::ostream &operator<<(std::ostream &out, const BusResponse &br);
 
-std::ostream &operator<<(std::ostream &out, const renderer_utils::Frame &frame);
+std::ostream &operator<<(std::ostream &out, const RoutingSettings &settings);
 
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RoutingSettings &settings);
+std::ostream &operator<<(std::ostream &out, const RenderingSettings &settings);
 
-std::ostream &operator<<(std::ostream &out, svg::Point point);
+std::ostream &operator<<(std::ostream &out, const RouteResponse::RoadItem &ri);
 
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RenderingSettings &settings);
-
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RouteResponse::RoadItem &ri);
-
-std::ostream &operator<<(std::ostream &out,
-                         const rm::RouteResponse::WaitItem &ri);
-
-std::ostream &operator<<(std::ostream &out, const rm::RouteResponse &rr);
+std::ostream &operator<<(std::ostream &out, const RouteResponse::WaitItem &ri);
 
 std::ostream &operator<<(std::ostream &out, const RouteResponse::Item &item);
+
+std::ostream &operator<<(std::ostream &out, const RouteResponse &rr);
+}
+
+namespace rm::renderer_utils {
+bool operator==(const Frame &lhs, const Frame &rhs);
+
+bool operator!=(const Frame &lhs, const Frame &rhs);
+
+std::ostream &operator<<(std::ostream &out, const Frame &frame);
+}
+
+namespace svg {
+bool operator==(Point lhs, Point rhs);
+
+bool operator!=(Point lhs, Point rhs);
+
+bool operator==(Rgb lhs, Rgb rhs);
+
+bool operator!=(Rgb lhs, Rgb rhs);
+
+bool operator==(Rgba lhs, Rgba rhs);
+
+bool operator!=(Rgba lhs, Rgba rhs);
+
+bool operator==(const Color &lhs, const Color &rhs);
+
+bool operator!=(const Color &lhs, const Color &rhs);
+
+std::ostream &operator<<(std::ostream &out, Point point);
 }
 
 #endif // ROOT_MANAGER_TESTS_TEST_UTILS_H_


### PR DESCRIPTION
Add using-directive where it is used a lot of times. Remove extra namespaces and constants. Move operators to the same namespace, where the object is declared to GoogleTest is able to use it.
