### PR TITLE
Refactor MapRenderer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ FetchContent_MakeAvailable(googletest)
 FetchContent_Declare(
         svg
         GIT_REPOSITORY https://github.com/siarheishut/svg.git
-        GIT_TAG v1.1
+        GIT_TAG v2.0
 )
 FetchContent_MakeAvailable(svg)
 

--- a/src/map_renderer.h
+++ b/src/map_renderer.h
@@ -7,7 +7,7 @@
 #include <string_view>
 #include <vector>
 
-#include "svg/document.h"
+#include "svg/figures.h"
 
 #include "coords_converter.h"
 #include "map_renderer_utils.h"
@@ -22,35 +22,38 @@ class MapRenderer {
       renderer_utils::Stops stops,
       const RenderingSettings &settings);
 
-  std::string GetMap() const;
+  std::string RenderMap() const;
+
  private:
   MapRenderer(const renderer_utils::Buses &buses,
               renderer_utils::Stops stops,
               const RenderingSettings &settings);
 
-  void AddBusLinesLayout(
+  static void AddBusLinesLayout(
+      svg::SectionBuilder &builder,
       const renderer_utils::Buses &buses,
-      const renderer_utils::Stops &stops,
       const rm::RenderingSettings &settings,
       const renderer_utils::StopCoords &coords);
 
-  void AddBusLabelsLayout(
+  static void AddBusLabelsLayout(
+      svg::SectionBuilder &builder,
       const renderer_utils::Buses &buses,
+      const rm::RenderingSettings &settings,
+      const renderer_utils::StopCoords &coords);
+
+  static void AddStopPointsLayout(
+      svg::SectionBuilder &builder,
       const renderer_utils::Stops &stops,
       const rm::RenderingSettings &settings,
       const renderer_utils::StopCoords &coords);
 
-  void AddStopPointsLayout(
+  static void AddStopLabelsLayout(
+      svg::SectionBuilder &builder,
       const renderer_utils::Stops &stops,
       const rm::RenderingSettings &settings,
       const renderer_utils::StopCoords &coords);
 
-  void AddStopLabelsLayout(
-      const renderer_utils::Stops &stops,
-      const rm::RenderingSettings &settings,
-      const renderer_utils::StopCoords &coords);
-
-  svg::Document map_;
+  svg::Section map_;
 };
 }
 

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -143,6 +143,6 @@ json::Dict Processor::Process(const GetRouteRequest &request) const {
 }
 
 json::Dict Processor::Process(const GetMapRequest &request) const {
-  return ToJson(MapResponse{.map = map_renderer_->GetMap()}, request.id);
+  return ToJson(MapResponse{.map = map_renderer_->RenderMap()}, request.id);
 }
 }

--- a/tests/map_renderer_test.cpp
+++ b/tests/map_renderer_test.cpp
@@ -171,7 +171,7 @@ TEST(TestMapRenderer, TestInitializing) {
   }
 }
 
-TEST(TestMapRenderer, TestGetMap) {
+TEST(TestMapRenderer, TestRenderMap) {
   using namespace rm;
 
   auto layers_replace_with = [&](std::vector<MapLayer> layers) {
@@ -361,7 +361,7 @@ TEST(TestMapRenderer, TestGetMap) {
   };
 
   for (auto &[name, buses, stops, settings, want] : test_cases) {
-    std::string got = MapRenderer::Create(buses, stops, settings)->GetMap();
+    std::string got = MapRenderer::Create(buses, stops, settings)->RenderMap();
     EXPECT_EQ(want, got) << name;
   }
 }


### PR DESCRIPTION
Change `svg` library tag to `v2.0` in order to use svg::Rectangle and svg::Section. 
Change method name from GetMap to RenderMap, because Getter is meant to have O(1) complexity and very simple logic, while this method no longer meets these requirments. 
Change field `map_` type from svg::Document to svg::Section in order not to render it on every Map call. 
Remove extra parameter in render functions and add SectionBuilder parameter to them.