### PR TITLE
Change route data representation format.

### DIFF
--- a/src/bus_manager.cpp
+++ b/src/bus_manager.cpp
@@ -57,7 +57,7 @@ BusManager::BusManager(std::vector<PostRequest> requests,
   for (auto &request : requests) {
     if (std::holds_alternative<PostBusRequest>(request)) {
       auto &bus = std::get<PostBusRequest>(request);
-      AddBus(std::move(bus.bus), std::move(bus.stops), bus.is_roundtrip);
+      AddBus(std::move(bus.bus), std::move(bus.stops));
     } else if (std::holds_alternative<PostStopRequest>(request)) {
       auto &stop = std::get<PostStopRequest>(request);
       AddStop(stop.stop,
@@ -67,10 +67,8 @@ BusManager::BusManager(std::vector<PostRequest> requests,
   }
 
   for (auto &[bus, bus_info] : bus_info_) {
-    double geo_dist = ComputeGeoDistance(bus_info.stops, stop_info_,
-                                         !bus_info.is_roundtrip);
-    bus_info.distance = ComputeRoadDistance(bus_info.stops, stop_info_,
-                                            !bus_info.is_roundtrip);
+    double geo_dist = ComputeGeoDistance(bus_info.stops, stop_info_);
+    bus_info.distance = ComputeRoadDistance(bus_info.stops, stop_info_);
     bus_info.unique_stop_count = ComputeUniqueCount(bus_info.stops);
     bus_info.curvature = bus_info.distance / geo_dist;
   }
@@ -98,15 +96,12 @@ void BusManager::AddStop(const std::string &stop, sphere::Coords coords,
   }
 }
 
-void BusManager::AddBus(std::string bus,
-                        std::vector<std::string> stops,
-                        bool is_roundtrip) {
+void BusManager::AddBus(std::string bus, std::vector<std::string> stops) {
   for (auto &stop : stops)
     stop_info_[stop].buses.push_back(bus);
 
   BusInfo bus_info;
   bus_info.stops = std::move(stops);
-  bus_info.is_roundtrip = is_roundtrip;
   bus_info_[std::move(bus)] = bus_info;
 }
 
@@ -116,12 +111,10 @@ std::optional<BusResponse> BusManager::GetBusInfo(const std::string &bus) const 
 
   auto &b = it->second;
   return BusResponse{
-      .stop_count = static_cast<int>(b.is_roundtrip ? b.stops.size() :
-                                     (2 * b.stops.size() - 1)),
+      .stop_count = static_cast<int>(b.stops.size()),
       .unique_stop_count = b.unique_stop_count,
       .length = b.distance,
       .curvature = b.curvature,
-      .is_roundtrip = b.is_roundtrip,
   };
 }
 

--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -17,7 +17,6 @@ struct BusResponse {
   int unique_stop_count;
   double length;
   double curvature;
-  bool is_roundtrip;
 };
 
 struct StopResponse {
@@ -46,8 +45,7 @@ class BusManager {
   void AddStop(const std::string &stop, sphere::Coords coords,
                const std::map<std::string, int> &stops);
 
-  void AddBus(std::string bus, std::vector<std::string> stops,
-              bool is_roundtrip);
+  void AddBus(std::string bus, std::vector<std::string> stops);
 
  private:
   StopDict stop_info_;

--- a/src/common.h
+++ b/src/common.h
@@ -2,13 +2,20 @@
 #define ROOT_MANAGER_SRC_COMMON_H_
 
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "request_types.h"
 
 namespace rm {
+struct Route {
+  std::vector<std::string_view> route;
+  std::unordered_set<std::string_view> endpoints;
+};
+
 struct StopInfo {
   using Dists = std::unordered_map<std::string, int>;
   // Distances to other stops.
@@ -22,7 +29,6 @@ struct BusInfo {
   int unique_stop_count;
   double distance;
   double curvature;
-  bool is_roundtrip;
 };
 
 struct RouteInfo {

--- a/src/coords_converter.cpp
+++ b/src/coords_converter.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 
 namespace rm::coords_converter {
-vector <string_view>
+vector<string_view>
 SortStops(const renderer_utils::Stops &stops, SortMode mode) {
   vector<pair<double, string_view>> sorted_stops;
   transform(begin(stops), end(stops), back_inserter(sorted_stops),
@@ -32,12 +32,11 @@ SortStops(const renderer_utils::Stops &stops, SortMode mode) {
 
 std::unordered_set<string_view>
 IntersectionsWithinRoute(const renderer_utils::Buses &buses, int count) {
-  unordered_set < string_view > base_stops;
+  unordered_set<string_view> base_stops;
   for (auto &[_, route] : buses) {
     unordered_map<string_view, int> stop_freqs;
     for (int i = 0; i < route.route.size(); ++i)
-      stop_freqs[route.route[i]] +=
-          (!route.is_roundtrip && i < route.route.size() - 1 ? 2 : 1);
+      ++stop_freqs[route.route[i]];
 
     for (auto &[stop, freq] : stop_freqs)
       if (freq >= count)
@@ -48,18 +47,18 @@ IntersectionsWithinRoute(const renderer_utils::Buses &buses, int count) {
 
 std::unordered_set<string_view>
 EndPoints(const renderer_utils::Buses &buses) {
-  unordered_set < string_view > base_stops;
+  unordered_set<string_view> base_stops;
   for (auto &[_, route] : buses) {
-    base_stops.insert(route.route.front());
-    if (!route.is_roundtrip)
-      base_stops.insert(route.route.back());
+    for (auto end_stop : route.endpoints) {
+      base_stops.insert(end_stop);
+    }
   }
   return base_stops;
 }
 
 std::unordered_set<string_view>
 IntersectionsCrossRoute(const renderer_utils::Buses &buses) {
-  unordered_set < string_view > base_stops, visited;
+  unordered_set<string_view> base_stops, visited;
   for (auto &[_, route] : buses) {
     for (auto stop : route.route)
       if (visited.find(stop) != visited.end())
@@ -146,8 +145,8 @@ StopLayers CompressNonadjacent(const std::vector<std::string_view> &stops,
   return result;
 }
 
-vector <pair<string_view, double>> SpreadStops(
-    const vector <vector<string_view>> &layers,
+vector<pair<string_view, double>> SpreadStops(
+    const vector<vector<string_view>> &layers,
     double from, double to) {
   int stop_count = layers.size();
   double step = (stop_count == 1) ? 0.0 : (to - from) / (stop_count - 1);

--- a/src/distance_computer.cpp
+++ b/src/distance_computer.cpp
@@ -7,19 +7,17 @@
 
 namespace rm {
 double ComputeGeoDistance(const std::vector<std::string> &stops,
-                          const StopDict &dict, bool two_way_bypass) {
+                          const StopDict &dict) {
   double distance = 0;
   for (int i = 1; i < stops.size(); ++i) {
     distance += sphere::CalculateDistance(dict.at(stops[i - 1]).coords,
                                           dict.at(stops[i]).coords);
   }
-  if (two_way_bypass)
-    distance *= 2;
   return distance;
 }
 
 double ComputeRoadDistance(const std::vector<std::string> &stops,
-                           const StopDict &dict, bool two_way_bypass) {
+                           const StopDict &dict) {
   double distance = 0;
   for (int i = 1; i < stops.size(); ++i) {
     auto &dists = dict.at(stops[i - 1]).dists;
@@ -29,17 +27,6 @@ double ComputeRoadDistance(const std::vector<std::string> &stops,
     else
       distance += sphere::CalculateDistance(dict.at(stops[i - 1]).coords,
                                             dict.at(stops[i]).coords);
-  }
-  if (two_way_bypass) {
-    for (int i = static_cast<int>(stops.size()) - 2; i >= 0; --i) {
-      auto &dists = dict.at(stops[i + 1]).dists;
-
-      if (auto found = dists.find(stops[i]); found != dists.end())
-        distance += found->second;
-      else
-        distance += sphere::CalculateDistance(dict.at(stops[i + 1]).coords,
-                                              dict.at(stops[i]).coords);
-    }
   }
   return distance;
 }

--- a/src/distance_computer.h
+++ b/src/distance_computer.h
@@ -8,10 +8,10 @@
 
 namespace rm {
 double ComputeGeoDistance(const std::vector<std::string> &stops,
-                          const StopDict &dict, bool two_way_bypass);
+                          const StopDict &dict);
 
 double ComputeRoadDistance(const std::vector<std::string> &stops,
-                           const StopDict &dict, bool two_way_bypass);
+                           const StopDict &dict);
 }
 
 #endif // ROOT_MANAGER_SRC_DISTANCE_COMPUTER_H_

--- a/src/map_renderer_utils.h
+++ b/src/map_renderer_utils.h
@@ -8,15 +8,11 @@
 
 #include "svg/common.h"
 
+#include "common.h"
 #include "sphere.h"
 
 namespace rm::renderer_utils {
-struct Route {
-  std::vector<std::string_view> route;
-  bool is_roundtrip;
-};
-
-using Buses = std::map<std::string_view, Route>;
+using Buses = std::map<std::string_view, rm::Route>;
 using Stops = std::map<std::string_view, rm::sphere::Coords>;
 using StopCoords = std::unordered_map<std::string_view, svg::Point>;
 }

--- a/src/request_parser.cpp
+++ b/src/request_parser.cpp
@@ -197,9 +197,15 @@ std::optional<PostBusRequest> ParsePostBusRequest(json::Dict dict) {
 
   PostBusRequest br;
   br.bus = name->second.ReleaseString();
-  br.is_roundtrip = is_roundtrip->second.AsBool();
   for (auto &stop : stops->second.ReleaseArray()) {
     br.stops.push_back(stop.ReleaseString());
+  }
+  br.endpoints.insert(br.stops.front());
+  if (!is_roundtrip->second.AsBool()) {
+    br.endpoints.insert(br.stops.back());
+    for (int i = static_cast<int>(br.stops.size()) - 2; i >= 0; --i) {
+      br.stops.push_back(br.stops[i]);
+    }
   }
 
   return br;

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -15,14 +15,15 @@ auto MapRendererParams(const std::vector<rm::PostRequest> &requests) {
   using namespace std;
   using namespace rm;
 
-  map<string_view, rm::renderer_utils::Route> buses;
+  map<string_view, rm::Route> buses;
   map<string_view, sphere::Coords> stops;
   for (auto &request : requests) {
     if (auto bus = get_if<PostBusRequest>(&request)) {
       buses.emplace(
           bus->bus,
-          rm::renderer_utils::Route{{begin(bus->stops), end(bus->stops)},
-                                    bus->is_roundtrip});
+          rm::Route{
+              .route = {begin(bus->stops), end(bus->stops)},
+              .endpoints = {begin(bus->endpoints), end(bus->endpoints)}});
     } else if (auto stop = get_if<PostStopRequest>(&request)) {
       stops[stop->stop] = stop->coords;
     }

--- a/src/request_types.h
+++ b/src/request_types.h
@@ -4,12 +4,13 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <unordered_set>
+#include <vector>
 #include <variant>
 #include <vector>
 
 #include "svg/common.h"
 
-#include "map_renderer_utils.h"
 #include "sphere.h"
 
 namespace rm {
@@ -67,7 +68,7 @@ struct GetMapRequest {
 struct PostBusRequest {
   std::string bus;
   std::vector<std::string> stops;
-  bool is_roundtrip;
+  std::unordered_set<std::string> endpoints;
 };
 
 struct PostStopRequest {

--- a/src/route_manager.cpp
+++ b/src/route_manager.cpp
@@ -9,18 +9,6 @@
 #include "distance_computer.h"
 #include "request_types.h"
 
-namespace {
-std::vector<std::string> Route(const rm::BusInfo &bus_info) {
-  auto route = bus_info.stops;
-  if (!bus_info.is_roundtrip) {
-    for (int i = static_cast<int>(route.size()) - 2; i >= 0; --i) {
-      route.push_back(route[i]);
-    }
-  }
-  return route;
-}
-}
-
 namespace rm {
 RouteManager::RouteManager(const rm::StopDict &stop_info,
                            const rm::BusDict &bus_info,
@@ -52,14 +40,13 @@ void RouteManager::ReadStops(const rm::StopDict &stop_dict) {
 void RouteManager::ReadBuses(const rm::BusDict &bus_dict,
                              const rm::StopDict &stop_dict) {
   for (auto &[bus, bus_info] : bus_dict) {
-    auto route = Route(bus_info);
+    auto &route = bus_info.stops;
     int stop_count = route.size();
     for (int from = 0; from + 1 < stop_count; ++from) {
       const auto depart = stop_ids_[route[from]].depart;
       double distance = 0.0;
       for (int to = from + 1; to < stop_count; ++to) {
-        distance += ComputeRoadDistance({route[to - 1], route[to]}, stop_dict,
-                                        false);
+        distance += ComputeRoadDistance({route[to - 1], route[to]}, stop_dict);
         edges_.emplace_back(RoadEdge{
             .bus = bus,
             .span_count = to - from});

--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -32,12 +32,10 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 1",
-                  .stops = {"stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = false,
+                  .stops = {"stop 2", "stop 3", "stop 1", "stop 3", "stop 2"},
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -63,12 +61,10 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = false,
+                  .stops = {"stop 2", "stop 3", "stop 1", "stop 3", "stop 2"},
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -135,12 +131,11 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = true,
       },
       TestCase{
-          .name = "Unknown stop along the route(roundtrip)",
+          .name = "Unknown stop along the route",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4", "stop 1"},
-                  .is_roundtrip = true,
+                  .stops = {"stop 1", "stop 2", "stop 4", "stop 2", "stop 1"},
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -159,60 +154,11 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = false,
       },
       TestCase{
-          .name = "Fixed \"Unknown stop along the route(roundtrip)\"",
+          .name = "Fixed \"Unknown stop along the route\"",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4", "stop 1"},
-                  .is_roundtrip = false,
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 4",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Unknown stop along the route(non-roundtrip)",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4"},
-                  .is_roundtrip = false,
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Fixed \"Unknown stop along the route(non-roundtrip)\"",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4"},
-                  .is_roundtrip = false,
+                  .stops = {"stop 1", "stop 2", "stop 4", "stop 2", "stop 1"},
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -280,12 +226,10 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 1", "stop 3"},
-                  .is_roundtrip = false,
+                  .stops = {"stop 2", "stop 1", "stop 3", "stop 1", "stop 2"},
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -312,34 +256,11 @@ TEST(TestFactoryMethod, TestInitializing) {
           .want = true,
       },
       TestCase{
-          .name = "Empty route(roundtrip)",
+          .name = "Empty route",
           .config = {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {},
-                  .is_roundtrip = true,
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 2000},},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Empty route(non-roundtrip)",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {},
-                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -361,17 +282,10 @@ TEST(TestFactoryMethod, TestInitializing) {
               PostBusRequest{
                   .bus = "Bus 1",
                   .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus 2",
                   .stops = {"stop 2", "stop 3", "stop 1", "stop 2"},
-                  .is_roundtrip = true,
-              },
-              PostBusRequest{
-                  .bus = "Bus 3",
-                  .stops = {"stop 3", "stop 2"},
-                  .is_roundtrip = false,
               },
               PostStopRequest{
                   .stop = "stop 1",
@@ -427,14 +341,12 @@ TEST(TestBusManager, TestGetBusInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3"},
-                  .is_roundtrip = false
+                  .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
               },
               PostBusRequest{
                   .bus = "Bus2",
                   .stops = {"stop4", "stop5", "stop6", "stop7", "stop8",
                             "stop4"},
-                  .is_roundtrip = true
               },
               PostStopRequest{
                   .stop = "stop1",
@@ -526,13 +438,12 @@ TEST(TestBusManager, TestGetStopInfo) {
           .config = {
               PostBusRequest{
                   .bus = "Bus1",
-                  .stops = {"stop1", "stop2", "stop3"},
-                  .is_roundtrip = false},
+                  .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
+              },
               PostBusRequest{
                   .bus = "Bus2",
                   .stops = {"stop3", "stop4", "stop5", "stop6", "stop7",
                             "stop3"},
-                  .is_roundtrip = true
               },
               PostStopRequest{
                   .stop = "stop1",
@@ -628,12 +539,10 @@ TEST(TestBusManager, TestFindRouteInfo) {
               PostBusRequest{
                   .bus = "Bus1",
                   .stops = {"stop1", "stop2", "stop3", "stop1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop2", "stop3", "stop4"},
-                  .is_roundtrip = false,
+                  .stops = {"stop2", "stop3", "stop4", "stop3", "stop2"},
               },
               PostStopRequest{
                   .stop = "stop1",
@@ -693,12 +602,10 @@ TEST(TestBusManager, TestFindRouteInfo) {
               PostBusRequest{
                   .bus = "Bus1",
                   .stops = {"stop1", "stop2", "stop3", "stop1"},
-                  .is_roundtrip = true
               },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop4", "stop5", "stop6"},
-                  .is_roundtrip = false
+                  .stops = {"stop4", "stop5", "stop6", "stop4", "stop5"},
               },
               PostStopRequest{
                   .stop = "stop1",
@@ -750,12 +657,10 @@ TEST(TestBusManager, TestFindRouteInfo) {
               PostBusRequest{
                   .bus = "Bus1",
                   .stops = {"stop1", "stop2", "stop3", "stop1"},
-                  .is_roundtrip = true,
               },
               PostBusRequest{
                   .bus = "Bus2",
-                  .stops = {"stop2", "stop3", "stop4"},
-                  .is_roundtrip = false,
+                  .stops = {"stop2", "stop3", "stop4", "stop3", "stop2"},
               },
               PostStopRequest{
                   .stop = "stop1",

--- a/tests/request_parser_test.cpp
+++ b/tests/request_parser_test.cpp
@@ -168,7 +168,7 @@ TEST(TestInputRequest, TestPostBusRequest) {
           .want = PostBusRequest{
               .bus = "Bus 1",
               .stops = {"stop1", "stop2", "stop3", "stop1"},
-              .is_roundtrip = true
+              .endpoints = {"stop1"},
           },
       },
       TestCase{
@@ -188,8 +188,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop3"},
-              .is_roundtrip = false
+              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
+              .endpoints = {"stop1", "stop3"},
           },
       },
       TestCase{
@@ -207,8 +207,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"stops", json::List{"stop1", "stop2", "stop3"}}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2", "stop3"},
-              .is_roundtrip = false
+              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
+              .endpoints = {"stop1", "stop3"},
           },
       },
       TestCase{
@@ -227,8 +227,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus 1",
-              .stops = {"stop1", "stop2"},
-              .is_roundtrip = false
+              .stops = {"stop1", "stop2", "stop1"},
+              .endpoints = {"stop1", "stop2"},
           },
       },
       TestCase{
@@ -240,8 +240,8 @@ TEST(TestInputRequest, TestPostBusRequest) {
                               {"is_roundtrip", false}},
           .want = PostBusRequest{
               .bus = "Bus1",
-              .stops = {"stop1", "stop2", "stop3"},
-              .is_roundtrip = false
+              .stops = {"stop1", "stop2", "stop3", "stop2", "stop1"},
+              .endpoints = {"stop1", "stop3"},
           },
       },
       TestCase{
@@ -255,7 +255,7 @@ TEST(TestInputRequest, TestPostBusRequest) {
           .want = PostBusRequest{
               .bus = "Bus1",
               .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              .is_roundtrip = true,
+              .endpoints = {"stop 1"},
           }
       },
       TestCase{

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -4,11 +4,13 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "svg/common.h"
 
 #include "src/map_renderer_utils.h"
+#include "src/request_types.h"
 
 using namespace std;
 
@@ -42,8 +44,8 @@ bool operator==(const BusResponse &lhs, const BusResponse &rhs) {
 }
 
 bool operator==(const PostBusRequest &lhs, const PostBusRequest &rhs) {
-  return tie(lhs.bus, lhs.stops, lhs.is_roundtrip)
-      == tie(rhs.bus, rhs.stops, rhs.is_roundtrip);
+  return tie(lhs.bus, lhs.stops, lhs.endpoints) ==
+      tie(rhs.bus, rhs.stops, rhs.endpoints);
 }
 
 bool operator==(const PostStopRequest &lhs, const PostStopRequest &rhs) {
@@ -168,7 +170,7 @@ ostream &operator<<(ostream &out, const vector<T> &str_v) {
 }
 
 ostream &operator<<(ostream &out, const PostBusRequest &br) {
-  return out << br.bus << ": " << br.stops << ' ' << br.is_roundtrip;
+  return out << br.bus << ": " << br.stops << ". Endpoints: " << br.endpoints;
 }
 
 ostream &operator<<(ostream &out, const PostStopRequest &sr) {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -3,6 +3,7 @@
 
 #include <ostream>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "svg/common.h"
@@ -70,6 +71,14 @@ bool operator!=(const RouteResponse::RoadItem &lhs,
 bool operator==(const RouteResponse &lhs, const RouteResponse &rhs);
 
 bool operator!=(const RouteResponse &lhs, const RouteResponse &rhs);
+
+template<typename T>
+std::ostream &operator<<(std::ostream &out,
+                         const std::unordered_set<T> &items) {
+  for (auto &item : items)
+    out << ' ' << item;
+  return out;
+}
 
 std::ostream &operator<<(std::ostream &out, const PostBusRequest &br);
 


### PR DESCRIPTION
Maintaint expanded routes and it's endpoints instead of non-expanded route and is_roundtrip bool. Fix all tests in appropriate way.