### PR TITLE
Update process function for RouteResponse.

### DIFF
--- a/src/request_processor.h
+++ b/src/request_processor.h
@@ -19,7 +19,8 @@ struct MapResponse {
 json::Dict ToJson(std::optional<BusResponse> resp, int id);
 json::Dict ToJson(std::optional<StopResponse> resp, int id);
 json::List ToJson(std::vector<RouteResponse::Item> response_items);
-json::Dict ToJson(std::optional<RouteResponse> resp, int id);
+json::Dict ToJson(std::optional<RouteResponse> response,
+                  std::optional<std::string> map, int id);
 json::Dict ToJson(MapResponse resp, int id);
 
 class Processor {


### PR DESCRIPTION
Fix RenderRoute test.
Add key `map' in output map of RouteResponse if route is found. Update tests accordingly.