### PR TITLE
Add TransportCatalog to BusManager.

### DIFF
--- a/src/bus_manager.cpp
+++ b/src/bus_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -12,6 +13,7 @@
 #include <vector>
 
 #include "distance_computer.h"
+#include "transport_catalog.h"
 
 using namespace rm::utils;
 
@@ -24,91 +26,19 @@ int ComputeUniqueCount(std::vector<std::string> stops) {
 }
 
 namespace rm {
-std::unique_ptr<BusManager> BusManager::Create(
-    std::vector<PostRequest> requests,
-    const RoutingSettings &routing_settings) {
-  std::set<std::string_view> route_stops, road_dists_stops, stop_requests_stops;
-  std::set<std::string_view> buses;
-  for (auto &req : requests) {
-    if (auto ptr_b = std::get_if<PostBusRequest>(&req)) {
-      if (ptr_b->stops.empty()) return nullptr;
-      route_stops.insert(ptr_b->stops.begin(), ptr_b->stops.end());
-      if (!buses.insert(ptr_b->bus).second)
-        return nullptr;
-    } else if (auto ptr_s = std::get_if<PostStopRequest>(&req)) {
-      for (auto &[dst_stop, dist] : ptr_s->stop_distances) {
-        road_dists_stops.insert(dst_stop);
-      }
-      if (!stop_requests_stops.insert(ptr_s->stop).second)
-        return nullptr;
-    }
-  }
-  if (!std::includes(begin(stop_requests_stops), end(stop_requests_stops),
-                     begin(route_stops), end(route_stops)))
-    return nullptr;
-  if (!std::includes(begin(stop_requests_stops), end(stop_requests_stops),
-                     begin(road_dists_stops), end(road_dists_stops)))
-    return nullptr;
+BusManager::BusManager(std::shared_ptr<TransportCatalog> transport_catalog,
+                       const RoutingSettings &routing_settings)
+    : transport_catalog_(transport_catalog) {
 
-  return std::unique_ptr<BusManager>(new BusManager(std::move(requests),
-                                                    routing_settings));
-}
-
-BusManager::BusManager(std::vector<PostRequest> requests,
-                       const RoutingSettings &routing_settings) {
-  for (auto &request : requests) {
-    if (std::holds_alternative<PostBusRequest>(request)) {
-      auto &bus = std::get<PostBusRequest>(request);
-      AddBus(std::move(bus.bus), std::move(bus.stops));
-    } else if (std::holds_alternative<PostStopRequest>(request)) {
-      auto &stop = std::get<PostStopRequest>(request);
-      AddStop(stop.stop,
-              stop.coords,
-              stop.stop_distances);
-    }
-  }
-
-  for (auto &[bus, bus_info] : bus_info_) {
-    double geo_dist = ComputeGeoDistance(bus_info.stops, stop_info_);
-    bus_info.distance = ComputeRoadDistance(bus_info.stops, stop_info_);
-    bus_info.unique_stop_count = ComputeUniqueCount(bus_info.stops);
-    bus_info.curvature = bus_info.distance / geo_dist;
-  }
-  for (auto &[_, info] : stop_info_) {
-    auto &buses = info.buses;
-    std::sort(buses.begin(), buses.end());
-    buses.erase(std::unique(buses.begin(), buses.end()),
-                buses.end());
-  }
   route_manager_ =
-      std::make_unique<RouteManager>(stop_info_, bus_info_, routing_settings);
-}
-
-void BusManager::AddStop(const std::string &stop, sphere::Coords coords,
-                         const std::map<std::string, int> &stops) {
-  auto &info = stop_info_[stop];
-  info.coords = {coords.latitude, coords.longitude};
-  for (auto &[stop_to, dist] : stops) {
-    auto &stop_to_dists = stop_info_[stop_to].dists;
-    if (auto it = stop_to_dists.find(stop); it == stop_to_dists.end()) {
-      stop_to_dists[stop] = dist;
-    }
-    info.dists[stop_to] = dist;
-  }
-}
-
-void BusManager::AddBus(std::string bus, std::vector<std::string> stops) {
-  for (auto &stop : stops)
-    stop_info_[stop].buses.push_back(bus);
-
-  BusInfo bus_info;
-  bus_info.stops = std::move(stops);
-  bus_info_[std::move(bus)] = bus_info;
+      std::make_unique<RouteManager>(transport_catalog_->Stops(),
+                                     transport_catalog_->Buses(),
+                                     routing_settings);
 }
 
 std::optional<BusResponse> BusManager::GetBusInfo(const std::string &bus) const {
-  auto it = bus_info_.find(bus);
-  if (it == bus_info_.end()) return std::nullopt;
+  auto it = transport_catalog_->Buses().find(bus);
+  if (it == transport_catalog_->Buses().end()) return std::nullopt;
 
   auto &b = it->second;
   return BusResponse{
@@ -120,8 +50,8 @@ std::optional<BusResponse> BusManager::GetBusInfo(const std::string &bus) const 
 }
 
 std::optional<StopResponse> BusManager::GetStopInfo(const std::string &stop) const {
-  auto it = stop_info_.find(stop);
-  if (it == stop_info_.end())
+  auto it = transport_catalog_->Stops().find(stop);
+  if (it == transport_catalog_->Stops().end())
     return std::nullopt;
 
   return StopResponse{it->second.buses};

--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -11,13 +11,13 @@
 #include "request_types.h"
 #include "response_types.h"
 #include "route_manager.h"
+#include "transport_catalog.h"
 
 namespace rm {
 class BusManager {
  public:
-  static std::unique_ptr<BusManager> Create(
-      std::vector<utils::PostRequest> requests,
-      const utils::RoutingSettings &routing_setting);
+  explicit BusManager(std::shared_ptr<TransportCatalog> transport_catalog,
+                      const utils::RoutingSettings &routing_setting);
 
   std::optional<utils::BusResponse> GetBusInfo(const std::string &bus) const;
 
@@ -27,17 +27,7 @@ class BusManager {
                                                const std::string &to) const;
 
  private:
-  explicit BusManager(std::vector<utils::PostRequest> requests,
-                      const utils::RoutingSettings &routing_settings);
-
-  void AddStop(const std::string &stop, sphere::Coords coords,
-               const std::map<std::string, int> &stops);
-
-  void AddBus(std::string bus, std::vector<std::string> stops);
-
- private:
-  utils::StopDict stop_info_;
-  utils::BusDict bus_info_;
+  std::shared_ptr<TransportCatalog> transport_catalog_;
   std::unique_ptr<RouteManager> route_manager_;
 };
 }

--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -17,304 +17,6 @@ const RoutingSettings kTestRoutingSettings{
     .bus_velocity = 54.0
 };
 
-TEST(TestFactoryMethod, TestInitializing) {
-  using namespace rm;
-
-  struct TestCase {
-    std::string name;
-    std::vector<PostRequest> config;
-    RoutingSettings routing_settings;
-    bool want;
-  };
-
-  std::vector<TestCase> test_cases{
-      TestCase{
-          .name = "Bus redefinition",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 2", "stop 3", "stop 1", "stop 3", "stop 2"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 10000}, {"stop 3", 20000}}
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 7000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Fixed \"Bus redefinition\"",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
-              PostBusRequest{
-                  .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 3", "stop 1", "stop 3", "stop 2"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 10000}, {"stop 3", 20000}}
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 7000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Stop redefinition",
-          .config = {
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {44.444444, 44.444444},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Fixed \"Stop redefinition\"",
-          .config = {
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 4",
-                  .coords = {44.444444, 44.444444},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Unknown stop along the route",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4", "stop 2", "stop 1"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Fixed \"Unknown stop along the route\"",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 4", "stop 2", "stop 1"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-              },
-              PostStopRequest{
-                  .stop = "stop 4",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Unknown stop among road_distances",
-          .config = {
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 4", 5000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-                  .stop_distances = {{"stop 1", 4000}},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Fixed \"Unknown stop among road_distances\"",
-          .config = {
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 5000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-                  .stop_distances = {{"stop 1", 4000}},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Unused stop",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
-              PostBusRequest{
-                  .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 1", "stop 3", "stop 1", "stop 2"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-                  .stop_distances = {{"stop 4", 5000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 4",
-                  .coords = {44.444444, 44.444444},
-                  .stop_distances = {{"stop 1", 4000}},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-      TestCase{
-          .name = "Empty route",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 2000},},
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 2000},},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = false,
-      },
-      TestCase{
-          .name = "Correct data",
-          .config = {
-              PostBusRequest{
-                  .bus = "Bus 1",
-                  .stops = {"stop 1", "stop 2", "stop 3", "stop 1"},
-              },
-              PostBusRequest{
-                  .bus = "Bus 2",
-                  .stops = {"stop 2", "stop 3", "stop 1", "stop 2"},
-              },
-              PostStopRequest{
-                  .stop = "stop 1",
-                  .coords = {11.111111, 11.111111},
-                  .stop_distances = {{"stop 2", 10000}, {"stop 3", 20000}}
-              },
-              PostStopRequest{
-                  .stop = "stop 2",
-                  .coords = {22.222222, 22.222222},
-                  .stop_distances = {{"stop 3", 7000}},
-              },
-              PostStopRequest{
-                  .stop = "stop 3",
-                  .coords = {33.333333, 33.333333},
-              },
-          },
-          .routing_settings = kTestRoutingSettings,
-          .want = true,
-      },
-  };
-
-  for (auto &[name, config, routing_settings, want] : test_cases) {
-    bool got = BusManager::Create(config, routing_settings) != nullptr;
-    EXPECT_EQ(want, got) << name;
-  }
-}
-
 TEST(TestBusManager, TestGetBusInfo) {
   using namespace rm;
 
@@ -387,13 +89,15 @@ TEST(TestBusManager, TestGetBusInfo) {
       },
   };
 
-  for (auto &[name, test_item, routing_settings, requests, want] : test_cases) {
-    auto bm = BusManager::Create(test_item, routing_settings);
-    EXPECT_TRUE(bm) << name;
-    if (!bm) continue;
+  for (auto &[name, config, routing_settings, requests, want] : test_cases) {
+    auto catalog = TransportCatalog::Create(config);
+    EXPECT_TRUE(catalog) << name;
+    if (!catalog) continue;
+
+    auto bm = BusManager(std::move(catalog), routing_settings);
 
     for (int i = 0; i < requests.size(); ++i) {
-      auto got = bm->GetBusInfo(requests[i].bus);
+      auto got = bm.GetBusInfo(requests[i].bus);
 
       if (!want[i].has_value()) {
         EXPECT_TRUE(!got.has_value()) << name;
@@ -485,13 +189,15 @@ TEST(TestBusManager, TestGetStopInfo) {
       },
   };
 
-  for (auto &[name, test_item, routing_settings, requests, want] : test_cases) {
-    auto bm = BusManager::Create(test_item, routing_settings);
-    EXPECT_TRUE(bm) << name;
-    if (!bm) continue;
+  for (auto &[name, config, routing_settings, requests, want] : test_cases) {
+    auto catalog = TransportCatalog::Create(config);
+    EXPECT_TRUE(catalog) << name;
+    if (!catalog) continue;
+
+    auto bm = BusManager(std::move(catalog), routing_settings);
 
     for (int i = 0; i < requests.size(); ++i) {
-      auto got = bm->GetStopInfo(requests[i].stop);
+      auto got = bm.GetStopInfo(requests[i].stop);
 
       EXPECT_EQ(want[i].has_value(), got.has_value()) << name;
       if (!got) continue;
@@ -703,12 +409,14 @@ TEST(TestBusManager, TestFindRouteInfo) {
   };
 
   for (auto &[name, config, routing_settings, requests, want] : test_cases) {
-    auto bm = BusManager::Create(std::move(config), routing_settings);
-    EXPECT_TRUE(bm) << name;
-    if (!bm) continue;
+    auto catalog = TransportCatalog::Create(config);
+    EXPECT_TRUE(catalog) << name;
+    if (!catalog) continue;
+
+    auto bm = BusManager(std::move(catalog), routing_settings);
 
     for (int i = 0; i < requests.size(); ++i) {
-      auto got = bm->GetRoute(requests[i].from, requests[i].to);
+      auto got = bm.GetRoute(requests[i].from, requests[i].to);
 
       EXPECT_EQ(want[i].has_value(), got.has_value()) << name;
       if (!got || !want[i]) continue;
@@ -717,3 +425,4 @@ TEST(TestBusManager, TestFindRouteInfo) {
     }
   }
 }
+


### PR DESCRIPTION
Remove factory method in BusManager, change constructor and make it public section.
Remove redundant methods.
Make BusManager maintain TransportCatalog.
Fix tests for BusManager.