### PR TITLE
Modify coords_converter module.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -52,6 +52,7 @@ struct RouteInfo {
 
 using StopDict = std::map<std::string, StopInfo>;
 using BusDict = std::map<std::string, BusInfo>;
+using StopCoords = std::unordered_map<std::string_view, sphere::Coords>;
 
 template<typename C, typename ...Args>
 void Combine(C &container, Args... args) {

--- a/src/coords_converter.cpp
+++ b/src/coords_converter.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace rm::coords_converter {
 vector<string_view>
-SortStops(const renderer_utils::Stops &stops, SortMode mode) {
+SortStops(const utils::StopCoords &stops, SortMode mode) {
   vector<pair<double, string_view>> sorted_stops;
   transform(begin(stops), end(stops), back_inserter(sorted_stops),
             [mode](auto &item) {
@@ -31,12 +31,12 @@ SortStops(const renderer_utils::Stops &stops, SortMode mode) {
 }
 
 std::unordered_set<string_view>
-IntersectionsWithinRoute(const renderer_utils::Buses &buses, int count) {
+IntersectionsWithinRoute(const utils::BusDict &buses, int count) {
   unordered_set<string_view> base_stops;
   for (auto &[_, route] : buses) {
     unordered_map<string_view, int> stop_freqs;
-    for (int i = 0; i < route.route.size(); ++i)
-      ++stop_freqs[route.route[i]];
+    for (int i = 0; i < route.stops.size(); ++i)
+      ++stop_freqs[route.stops[i]];
 
     for (auto &[stop, freq] : stop_freqs)
       if (freq >= count)
@@ -46,7 +46,7 @@ IntersectionsWithinRoute(const renderer_utils::Buses &buses, int count) {
 }
 
 std::unordered_set<string_view>
-EndPoints(const renderer_utils::Buses &buses) {
+EndPoints(const utils::BusDict &buses) {
   unordered_set<string_view> base_stops;
   for (auto &[_, route] : buses) {
     for (auto end_stop : route.endpoints) {
@@ -57,22 +57,22 @@ EndPoints(const renderer_utils::Buses &buses) {
 }
 
 std::unordered_set<string_view>
-IntersectionsCrossRoute(const renderer_utils::Buses &buses) {
+IntersectionsCrossRoute(const utils::BusDict &buses) {
   unordered_set<string_view> base_stops, visited;
   for (auto &[_, route] : buses) {
-    for (auto stop : route.route)
+    for (auto stop : route.stops)
       if (visited.find(stop) != visited.end())
         base_stops.insert(stop);
 
-    for (auto stop : route.route) {
+    for (auto stop : route.stops) {
       visited.insert(stop);
     }
   }
   return base_stops;
 }
 
-renderer_utils::Stops Interpolate(
-    renderer_utils::Stops stops,
+utils::StopCoords Interpolate(
+    utils::StopCoords stops,
     const std::vector<std::string_view> &route,
     const std::unordered_set<std::string_view> &base_stops) {
   auto is_base =
@@ -104,10 +104,10 @@ renderer_utils::Stops Interpolate(
   return std::move(stops);
 }
 
-AdjacentList AdjacentStops(const renderer_utils::Buses &buses) {
+AdjacentList AdjacentStops(const utils::BusDict &buses) {
   AdjacentList adj_stops;
   for (auto &bus : buses) {
-    auto &route = bus.second.route;
+    auto &route = bus.second.stops;
     for (int i = 1; i < route.size(); ++i) {
       if (route[i] == route[i - 1]) continue;
       adj_stops[route[i]].insert(route[i - 1]);

--- a/src/coords_converter.h
+++ b/src/coords_converter.h
@@ -9,7 +9,7 @@
 
 #include "svg/common.h"
 
-#include "map_renderer_utils.h"
+#include "common.h"
 #include "request_types.h"
 #include "sphere.h"
 
@@ -22,18 +22,18 @@ using StopLayers = std::vector<std::vector<std::string_view>>;
 enum class SortMode { kByLatitude, kByLongitude };
 
 std::vector<std::string_view>
-SortStops(const renderer_utils::Stops &stops, SortMode mode);
+SortStops(const utils::StopCoords &stops, SortMode mode);
 
 // IntersectionsWithinRoute returns stops that are present within the same route
 // at least `count` times.
 std::unordered_set<std::string_view>
-IntersectionsWithinRoute(const renderer_utils::Buses &buses, int count);
+IntersectionsWithinRoute(const utils::BusDict &buses, int count);
 
 std::unordered_set<std::string_view>
-EndPoints(const renderer_utils::Buses &buses);
+EndPoints(const utils::BusDict &buses);
 
 std::unordered_set<std::string_view>
-IntersectionsCrossRoute(const renderer_utils::Buses &buses);
+IntersectionsCrossRoute(const utils::BusDict &buses);
 
 // Interpolates coordinates of the stops along the route:
 // distributes the non-base stops of the route at equal distances
@@ -42,12 +42,12 @@ IntersectionsCrossRoute(const renderer_utils::Buses &buses);
 // Doesn't modify base stops' coordinates.
 // The base_stops must contain the first and the last route's stop.
 // Empty route is always valid and leaves stops unmodified.
-renderer_utils::Stops Interpolate(
-    renderer_utils::Stops stops,
+utils::StopCoords Interpolate(
+    utils::StopCoords stops,
     const std::vector<std::string_view> &route,
     const std::unordered_set<std::string_view> &base_stops);
 
-AdjacentList AdjacentStops(const renderer_utils::Buses &buses);
+AdjacentList AdjacentStops(const utils::BusDict &buses);
 
 StopLayers CompressNonadjacent(const std::vector<std::string_view> &stops,
                                const AdjacentList &adj_stops);


### PR DESCRIPTION
Change `StopCoords` used in MapRenderer to `StopPoints`, because it better reflects meaning. 
Add alias StopCoords and change `Stops` to `StopCoords` in coords_converter module to avoid coping fields, which won't be used. 
Fix tests.