### PR TITLE
Change StopCoords alias.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "sphere.h"
 #include "request_types.h"
 
 namespace rm::utils {
@@ -52,6 +53,7 @@ struct RouteInfo {
 
 using StopDict = std::map<std::string, StopInfo>;
 using BusDict = std::map<std::string, BusInfo>;
+using StopCoords = std::unordered_map<std::string_view, sphere::Coords>;
 
 template<typename C, typename ...Args>
 void Combine(C &container, Args... args) {

--- a/src/coords_converter.cpp
+++ b/src/coords_converter.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace rm::coords_converter {
 vector<string_view>
-SortStops(const renderer_utils::Stops &stops, SortMode mode) {
+SortStops(const utils::StopCoords &stops, SortMode mode) {
   vector<pair<double, string_view>> sorted_stops;
   transform(begin(stops), end(stops), back_inserter(sorted_stops),
             [mode](auto &item) {
@@ -71,8 +71,8 @@ IntersectionsCrossRoute(const renderer_utils::Buses &buses) {
   return base_stops;
 }
 
-renderer_utils::Stops Interpolate(
-    renderer_utils::Stops stops,
+utils::StopCoords Interpolate(
+    utils::StopCoords stops,
     const std::vector<std::string_view> &route,
     const std::unordered_set<std::string_view> &base_stops) {
   auto is_base =

--- a/src/coords_converter.h
+++ b/src/coords_converter.h
@@ -22,7 +22,7 @@ using StopLayers = std::vector<std::vector<std::string_view>>;
 enum class SortMode { kByLatitude, kByLongitude };
 
 std::vector<std::string_view>
-SortStops(const renderer_utils::Stops &stops, SortMode mode);
+SortStops(const utils::StopCoords &stops, SortMode mode);
 
 // IntersectionsWithinRoute returns stops that are present within the same route
 // at least `count` times.
@@ -42,8 +42,8 @@ IntersectionsCrossRoute(const renderer_utils::Buses &buses);
 // Doesn't modify base stops' coordinates.
 // The base_stops must contain the first and the last route's stop.
 // Empty route is always valid and leaves stops unmodified.
-renderer_utils::Stops Interpolate(
-    renderer_utils::Stops stops,
+utils::StopCoords Interpolate(
+    utils::StopCoords stops,
     const std::vector<std::string_view> &route,
     const std::unordered_set<std::string_view> &base_stops);
 

--- a/src/map_renderer.h
+++ b/src/map_renderer.h
@@ -39,7 +39,7 @@ class MapRenderer {
   };
   using Buses = std::unordered_map<std::string, BusInfo>;
 
-  using StopCoords = std::unordered_map<std::string, svg::Point>;
+  using StopPoints = std::unordered_map<std::string, svg::Point>;
 
   MapRenderer(const renderer_utils::Buses &buses,
               renderer_utils::Stops stops,
@@ -54,31 +54,31 @@ class MapRenderer {
 
   static std::vector<svg::Point> Points(
       const std::vector<std::string> &route,
-      const StopCoords &coords);
+      const StopPoints &points);
 
   static void AddBusLinesLayout(
       svg::SectionBuilder &builder,
       const Buses &buses,
       const rm::utils::RenderingSettings &settings,
-      const StopCoords &coords);
+      const StopPoints &points);
 
   static void AddBusLabelsLayout(
       svg::SectionBuilder &builder,
       const Buses &buses,
       const rm::utils::RenderingSettings &settings,
-      const StopCoords &coords);
+      const StopPoints &points);
 
   static void AddStopPointsLayout(
       svg::SectionBuilder &builder,
       const renderer_utils::Stops &stops,
       const rm::utils::RenderingSettings &settings,
-      const StopCoords &coords);
+      const StopPoints &points);
 
   static void AddStopLabelsLayout(
       svg::SectionBuilder &builder,
       const renderer_utils::Stops &stops,
       const rm::utils::RenderingSettings &settings,
-      const StopCoords &coords);
+      const StopPoints &points);
 
   svg::Section BusLinesFor(const utils::RouteInfo::RoadItem &item) const;
 
@@ -91,7 +91,7 @@ class MapRenderer {
 
   svg::Section map_;
   Buses buses_;
-  StopCoords stop_coords_;
+  StopPoints stop_points_;
   rm::utils::RenderingSettings settings_;
 };
 }

--- a/tests/coords_converter_test.cpp
+++ b/tests/coords_converter_test.cpp
@@ -24,7 +24,7 @@ const std::pair<std::string_view, rm::sphere::Coords> kClemens =
 TEST(TestSortStops, TestSortByLatitude) {
   struct TestCase {
     string name;
-    rm::renderer_utils::Stops stops;
+    rm::utils::StopCoords stops;
     vector<string_view> want;
   };
 
@@ -55,7 +55,7 @@ TEST(TestSortStops, TestSortByLatitude) {
 TEST(TestSortStops, TestSortByLongitude) {
   struct TestCase {
     string name;
-    rm::renderer_utils::Stops stops;
+    rm::utils::StopCoords stops;
     vector<string_view> want;
   };
 
@@ -378,8 +378,8 @@ TEST(TestInterpolation, TestInterpolation) {
     string name;
     vector<string_view> route;
     unordered_set<string_view> base_stops;
-    rm::renderer_utils::Stops stops;
-    rm::renderer_utils::Stops want;
+    rm::utils::StopCoords stops;
+    rm::utils::StopCoords want;
   };
 
   vector<TestCase> test_cases{


### PR DESCRIPTION
Change StopCoords to StopPoints in MapRenderer, because it better reflects the assignment. 
Add alias StopCoords and use it in coords_converter module in order to avoid coping fields, that won't be used.
Fix tests.