### PR TITLE
Add utils for RouteManager and modify its internal data.

### DIFF
--- a/src/bus_manager.cpp
+++ b/src/bus_manager.cpp
@@ -31,9 +31,9 @@ BusManager::BusManager(std::shared_ptr<TransportCatalog> transport_catalog,
     : transport_catalog_(transport_catalog) {
 
   route_manager_ =
-      std::make_unique<RouteManager>(transport_catalog_->Stops(),
-                                     transport_catalog_->Buses(),
-                                     routing_settings);
+      std::make_unique<route_manager::RouteManager>(transport_catalog_->Stops(),
+                                                    transport_catalog_->Buses(),
+                                                    routing_settings);
 }
 
 std::optional<BusResponse> BusManager::GetBusInfo(const std::string &bus) const {

--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -28,7 +28,7 @@ class BusManager {
 
  private:
   std::shared_ptr<TransportCatalog> transport_catalog_;
-  std::unique_ptr<RouteManager> route_manager_;
+  std::unique_ptr<route_manager::RouteManager> route_manager_;
 };
 }
 

--- a/src/route_manager.h
+++ b/src/route_manager.h
@@ -12,13 +12,10 @@
 
 #include "common.h"
 #include "request_types.h"
+#include "route_manager_utils.h"
 
-namespace rm {
+namespace rm::route_manager {
 class RouteManager {
- private:
-  using Graph = graph::DirectedWeightedGraph<double>;
-  using Router = graph::Router<double>;
-
  public:
   RouteManager(const rm::utils::StopDict &stop_info,
                const rm::utils::BusDict &bus_info,
@@ -32,27 +29,12 @@ class RouteManager {
   void ReadBuses(const rm::utils::BusDict &stop_dict,
                  const rm::utils::StopDict &bus_dict);
 
-  struct StopIds {
-    graph::VertexId arrive;
-    graph::VertexId depart;
-  };
-
-  struct RoadEdge {
-    std::string bus;
-    int start_idx;
-    int span_count;
-  };
-  struct WaitEdge {};
-
-  using Edge = std::variant<RoadEdge, WaitEdge>;
-  using Vertex = std::string;
-
   std::unique_ptr<Router> router_;
   Graph graph_;
   rm::utils::RoutingSettings settings_;
   std::vector<Edge> edges_;
-  std::vector<Vertex> vertices_;
-  std::unordered_map<std::string, StopIds> stop_ids_;
+  std::vector<std::string> stop_names_;
+  std::unordered_map<std::string, size_t> stop_ids_;
 };
 }
 

--- a/src/route_manager_utils.h
+++ b/src/route_manager_utils.h
@@ -1,0 +1,24 @@
+#ifndef ROOT_MANAGER_SRC_ROUTE_MANAGER_UTILS_H_
+#define ROOT_MANAGER_SRC_ROUTE_MANAGER_UTILS_H_
+
+#include <string>
+#include <variant>
+
+#include "graph.h"
+#include "router.h"
+
+namespace rm::route_manager {
+using Graph = graph::DirectedWeightedGraph<double>;
+using Router = graph::Router<double>;
+
+struct RoadEdge {
+  std::string bus;
+  int start_idx;
+  int span_count;
+};
+struct WaitEdge {};
+
+using Edge = std::variant<RoadEdge, WaitEdge>;
+}
+
+#endif // ROOT_MANAGER_SRC_ROUTE_MANAGER_UTILS_H_


### PR DESCRIPTION
Maintain maps 'stop->stop_id' and 'stop_id->stop' and add functions to calculate vertex statuses instead of maintaining 'stop->vertex_ids'. 
Create rm::RouteManager namespace for RouteManager class and its utils.