### PR TITLE
Fix Router factory method.

### DIFF
--- a/lib/graph/src/router.h
+++ b/lib/graph/src/router.h
@@ -208,7 +208,7 @@ std::unique_ptr<Router<Weight>> Router<Weight>::Deserialize(
     st.emplace(from, to);
     st.emplace(from, second_to_last);
   }
-  return std::make_unique<Router>(graph, routes_internal_data);
+  return std::unique_ptr<Router>(new Router(graph, routes_internal_data));
 }
 
 template<typename Weight>


### PR DESCRIPTION
Change `std::make_unique` call to `std::unique_ptr` constructor in order to be able to call class private constructor.