### PR TITLE
Move RouteManager.

### DIFF
--- a/src/bus_manager.cpp
+++ b/src/bus_manager.cpp
@@ -27,13 +27,9 @@ int ComputeUniqueCount(std::vector<std::string> stops) {
 
 namespace rm {
 BusManager::BusManager(std::shared_ptr<TransportCatalog> transport_catalog,
-                       const RoutingSettings &routing_settings)
-    : transport_catalog_(transport_catalog) {
-
-  route_manager_ =
-      std::make_unique<RouteManager>(transport_catalog_->Stops(),
-                                     transport_catalog_->Buses(),
-                                     routing_settings);
+                       std::shared_ptr<RouteManager> route_manager)
+    : transport_catalog_(std::move(transport_catalog)),
+      route_manager_(std::move(route_manager)) {
 }
 
 std::optional<BusResponse> BusManager::GetBusInfo(const std::string &bus) const {

--- a/src/bus_manager.h
+++ b/src/bus_manager.h
@@ -17,7 +17,7 @@ namespace rm {
 class BusManager {
  public:
   explicit BusManager(std::shared_ptr<TransportCatalog> transport_catalog,
-                      const utils::RoutingSettings &routing_setting);
+                      std::shared_ptr<RouteManager> route_manager);
 
   std::optional<utils::BusResponse> GetBusInfo(const std::string &bus) const;
 
@@ -28,7 +28,7 @@ class BusManager {
 
  private:
   std::shared_ptr<TransportCatalog> transport_catalog_;
-  std::unique_ptr<RouteManager> route_manager_;
+  std::shared_ptr<RouteManager> route_manager_;
 };
 }
 

--- a/src/request_processor.h
+++ b/src/request_processor.h
@@ -31,6 +31,7 @@ class Processor {
 
  private:
   Processor(std::shared_ptr<TransportCatalog> catalog,
+            std::shared_ptr<RouteManager> route_manager,
             std::unique_ptr<BusManager> bus_manager,
             std::unique_ptr<MapRenderer> map_renderer);
 
@@ -40,6 +41,7 @@ class Processor {
   json::Dict Process(const utils::GetMapRequest &request) const;
 
   std::shared_ptr<TransportCatalog> catalog_;
+  std::shared_ptr<RouteManager> route_manager_;
   std::unique_ptr<BusManager> bus_manager_;
   std::unique_ptr<MapRenderer> map_renderer_;
 };

--- a/tests/bus_manager_test.cpp
+++ b/tests/bus_manager_test.cpp
@@ -94,7 +94,10 @@ TEST(TestBusManager, TestGetBusInfo) {
     EXPECT_TRUE(catalog) << name;
     if (!catalog) continue;
 
-    auto bm = BusManager(std::move(catalog), routing_settings);
+    auto route_manager = std::make_shared<rm::RouteManager>(catalog->Stops(),
+                                                            catalog->Buses(),
+                                                            routing_settings);
+    auto bm = BusManager(std::move(catalog), std::move(route_manager));
 
     for (int i = 0; i < requests.size(); ++i) {
       auto got = bm.GetBusInfo(requests[i].bus);
@@ -194,7 +197,10 @@ TEST(TestBusManager, TestGetStopInfo) {
     EXPECT_TRUE(catalog) << name;
     if (!catalog) continue;
 
-    auto bm = BusManager(std::move(catalog), routing_settings);
+    auto route_manager = std::make_shared<rm::RouteManager>(catalog->Stops(),
+                                                            catalog->Buses(),
+                                                            routing_settings);
+    auto bm = BusManager(std::move(catalog), std::move(route_manager));
 
     for (int i = 0; i < requests.size(); ++i) {
       auto got = bm.GetStopInfo(requests[i].stop);
@@ -413,7 +419,10 @@ TEST(TestBusManager, TestFindRouteInfo) {
     EXPECT_TRUE(catalog) << name;
     if (!catalog) continue;
 
-    auto bm = BusManager(std::move(catalog), routing_settings);
+    auto route_manager = std::make_shared<rm::RouteManager>(catalog->Stops(),
+                                                            catalog->Buses(),
+                                                            routing_settings);
+    auto bm = BusManager(std::move(catalog), std::move(route_manager));
 
     for (int i = 0; i < requests.size(); ++i) {
       auto got = bm.GetRoute(requests[i].from, requests[i].to);


### PR DESCRIPTION
Move RouteManager from BusManager to RequestProcessor in order to ease Serialization implementation in future.